### PR TITLE
Exposes OnClose event for modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,32 @@ Welcome to Blazored Modal.
 
 <button onclick="@(() => Modal.Show("My Movies", typeof(Movies)))" class="btn btn-primary">View Movies</button>
 ```
+
+If you need to know when the modal has closed, for example to trigger a update of data. The modal service exposes a `OnClose` event which you can attach to. 
+
+```html
+@page "/"
+@inject IModalService Modal
+
+<h1>Hello, world!</h1>
+
+Welcome to Blazored Modal.
+
+<button onclick="@ShowModal" class="btn btn-primary">View Movies</button>
+
+@functions {
+
+    void ShowModal()
+    {
+        Modal.OnClose += CloseModalCallback;
+        Modal.Show("My Movies", typeof(Movies));
+    }
+
+    void CloseModalCallback()
+    {
+        Console.WriteLine("Modal has closed");
+        Modal.OnClose -= CloseModalCallback;
+    }
+
+}
+```

--- a/samples/BlazorSample/Pages/Index.cshtml
+++ b/samples/BlazorSample/Pages/Index.cshtml
@@ -9,4 +9,20 @@ Welcome to your new app.
 
 <hr class="mb-5" />
 
-<button onclick="@(() => Modal.Show("Sign Up Form", typeof(SignUpForm)))" class="btn btn-primary">Show Modal</button>
+<button onclick="@(ShowModal)" class="btn btn-primary">Show Modal</button>
+
+@functions {
+
+    void ShowModal()
+    {
+        Modal.OnClose += CloseModalCallback;
+        Modal.Show("Sign Up Form", typeof(SignUpForm));
+    }
+
+    void CloseModalCallback()
+    {
+        Console.WriteLine("Modal has closed");
+        Modal.OnClose -= CloseModalCallback;
+    }
+
+}

--- a/src/Blazored.Modal/BlazoredModal.cshtml.cs
+++ b/src/Blazored.Modal/BlazoredModal.cshtml.cs
@@ -27,18 +27,17 @@ namespace Blazored.Modal
             Title = "";
             Content = null;
             StateHasChanged();
+            ModalService.Close();
         }
 
         public void Dispose()
         {
             ModalService.OnShow -= ShowModal;
-            ModalService.OnClose -= CloseModal;
         }
 
         protected override void OnInit()
         {
             ModalService.OnShow += ShowModal;
-            ModalService.OnClose += CloseModal;
         }
     }
 }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -12,6 +12,7 @@ namespace Blazored.Modal.Services
 
         public void Show(string title, Type contentType)
         {
+            Console.WriteLine(OnClose.Target.ToString());
             if (contentType.BaseType != typeof(BlazorComponent))
             {
                 throw new ArgumentException($"{contentType.FullName} must be a Blazor Component");


### PR DESCRIPTION
Fixes #2 

This PR correctly fires the OnClose event on the ModalService when the modal closes. Developers can now attach a handler to this event and it will be called when the modal closes. 