### PR TITLE
Add parameter for custom styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,10 @@ A custom style can also be set as a parameter on the `Modal.Show()` method.
 @code {
     void ShowModal()
     {
+		var options = new ModalOptions() { Style = "blazored-modal-movies" };
+
         Modal.OnClose += ModalClosed;
-        Modal.Show("My Movies", typeof(Movies), "blazored-modal-custom");
+        Modal.Show("My Movies", typeof(Movies), options);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -194,8 +194,13 @@ If you need to know when the modal has closed, for example to trigger an update 
 ```
 
 ### Custom CSS styling
-You can pass an alternative CSS style for the modal if you want to customize the look and feel of your modal. This is useful when your web application requires different kinds of modals, like a warning, confirmation or an input form.
+You can set an alternative CSS style for the modal if you want to customize the look and feel of your modal. This is useful when your web application requires different kinds of modals, like a warning, confirmation or an input form.
 
+To set a custom style globally, use:
+`<BlazoredModal Style="custom-modal" />`
+
+A custom style can also be set as a parameter on the `Modal.Show()` method.
+```csharp
 @code {
     void ShowModal()
     {
@@ -203,3 +208,4 @@ You can pass an alternative CSS style for the modal if you want to customize the
         Modal.Show("My Movies", typeof(Movies), "blazored-modal-custom");
     }
 }
+```

--- a/README.md
+++ b/README.md
@@ -192,3 +192,14 @@ If you need to know when the modal has closed, for example to trigger an update 
 
 }
 ```
+
+### Custom CSS styling
+You can pass an alternative CSS style for the modal if you want to customize the look and feel of your modal. This is useful when your web application requires different kinds of modals, like a warning, confirmation or an input form.
+
+@code {
+    void ShowModal()
+    {
+        Modal.OnClose += ModalClosed;
+        Modal.Show("My Movies", typeof(Movies), "blazored-modal-custom");
+    }
+}

--- a/samples/BlazorSample/Pages/BackGroundCancel.razor
+++ b/samples/BlazorSample/Pages/BackGroundCancel.razor
@@ -1,0 +1,35 @@
+﻿@page "/backgroundcancel"
+@inject IModalService Modal
+
+<h1>Click background to cancel</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A modal is cancelled by default if the user clicks outside the modal. This behavior can
+    be disabled.
+</p>
+<button @onclick="BackgroundCancelEnabled" class="btn btn-primary">Cancellation enabled</button>
+<button @onclick="BackgroundCancelDisabled" class="btn btn-secondary">Cancellation disabled</button>
+
+@code {
+
+    void BackgroundCancelEnabled()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+        var options = new ModalOptions() { DisableBackgroundCancel = false };
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+
+    void BackgroundCancelDisabled()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+        var options = new ModalOptions() { DisableBackgroundCancel = true };
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+}
+

--- a/samples/BlazorSample/Pages/CustomStyle.razor
+++ b/samples/BlazorSample/Pages/CustomStyle.razor
@@ -1,0 +1,60 @@
+﻿@page "/custom"
+@inject IModalService Modal
+@layout CustomModalLayout
+
+<h1>Blazored Modal Sample with Custom Styling</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A custom style can be set globally by adding the <var>Style</var> property on <code>BlazoredModal</code> like this:
+</p>
+<button @onclick="ShowModal" class="btn btn-primary">Show custom Modal</button>
+
+<hr class="mb-5" />
+
+<p>
+    A custom style can also be set as a parameter on the <code>Modal.Show()</code> method.
+</p>
+
+<button @onclick="@(ShowModalCustomStyle)" class="btn btn-primary">Show Modal styled as a prompt</button>
+
+@code {
+
+    void ShowModal()
+    {
+        var parameters = new ModalParameters();
+
+        parameters.Add("FormId", 11);
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
+    }
+
+    void ShowModalCustomStyle()
+    {
+        var parameters = new ModalParameters();
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show("Delete record?", typeof(YesNoPrompt), "blazored-prompt-modal");
+    }
+
+
+    void ModalClosed(ModalResult modalResult)
+    {
+        Console.WriteLine("Modal has closed");
+
+        if (modalResult.Cancelled)
+        {
+            Console.WriteLine("Modal was Cancelled");
+        }
+        else
+        {
+            Console.WriteLine(modalResult.Data.ToString());
+        }
+
+        Modal.OnClose -= ModalClosed;
+    }
+
+}
+

--- a/samples/BlazorSample/Pages/CustomStyle.razor
+++ b/samples/BlazorSample/Pages/CustomStyle.razor
@@ -34,9 +34,10 @@
     void ShowModalCustomStyle()
     {
         var parameters = new ModalParameters();
+        var options = new ModalOptions() { Style = "blazored-prompt-modal" };
 
         Modal.OnClose += ModalClosed;
-        Modal.Show("Delete record?", typeof(YesNoPrompt), "blazored-prompt-modal");
+        Modal.Show("Delete record?", typeof(YesNoPrompt), options);
     }
 
 

--- a/samples/BlazorSample/Pages/HideCloseButton.razor
+++ b/samples/BlazorSample/Pages/HideCloseButton.razor
@@ -1,0 +1,36 @@
+﻿@page "/closebutton"
+@inject IModalService Modal
+
+<h1>Hiding the modal close button</h1>
+
+<hr class="mb-5" />
+
+<p>
+    Blazored.Modal shows a close button in the modal by default. The button can be hidden if you
+    prefer to handle closing the modal yourself.
+</p>
+
+<button @onclick="CloseButtonShown" class="btn btn-primary">Show the close button</button>
+<button @onclick="CloseButtonHidden" class="btn btn-secondary">Hide the close button</button>
+
+@code {
+
+    void CloseButtonShown()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        var options = new ModalOptions() { HideCloseButton = false };
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+
+    void CloseButtonHidden()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        var options = new ModalOptions() { HideCloseButton = true };
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+}
+

--- a/samples/BlazorSample/Pages/Index.razor
+++ b/samples/BlazorSample/Pages/Index.razor
@@ -6,6 +6,7 @@
 <hr class="mb-5" />
 
 <button @onclick="@(ShowModal)" class="btn btn-primary">Show Modal</button>
+<button @onclick="@(ShowModalCustomStyle)" class="btn btn-outline-primary">Show Modal using custom style</button>
 
 @code {
 
@@ -17,6 +18,16 @@
 
         Modal.OnClose += ModalClosed;
         Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
+    }
+
+    void ShowModalCustomStyle()
+    {
+        var parameters = new ModalParameters();
+
+        parameters.Add("FormId", 11);
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, "blazored-custom-modal");
     }
 
     void ModalClosed(ModalResult modalResult)

--- a/samples/BlazorSample/Pages/Index.razor
+++ b/samples/BlazorSample/Pages/Index.razor
@@ -5,6 +5,11 @@
 
 <hr class="mb-5" />
 
+<p>
+    This example shows Blazored.Modal's default behavior, including opening a modal with
+    parameters and returning a result.
+</p>
+
 <button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
 
 @code {
@@ -12,7 +17,6 @@
     void ShowModal()
     {
         var parameters = new ModalParameters();
-
         parameters.Add("FormId", 11);
 
         Modal.OnClose += ModalClosed;

--- a/samples/BlazorSample/Pages/Index.razor
+++ b/samples/BlazorSample/Pages/Index.razor
@@ -5,8 +5,7 @@
 
 <hr class="mb-5" />
 
-<button @onclick="@(ShowModal)" class="btn btn-primary">Show Modal</button>
-<button @onclick="@(ShowModalCustomStyle)" class="btn btn-outline-primary">Show Modal using custom style</button>
+<button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
 
 @code {
 
@@ -18,16 +17,6 @@
 
         Modal.OnClose += ModalClosed;
         Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
-    }
-
-    void ShowModalCustomStyle()
-    {
-        var parameters = new ModalParameters();
-
-        parameters.Add("FormId", 11);
-
-        Modal.OnClose += ModalClosed;
-        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, "blazored-custom-modal");
     }
 
     void ModalClosed(ModalResult modalResult)
@@ -47,3 +36,4 @@
     }
 
 }
+

--- a/samples/BlazorSample/Pages/Position.razor
+++ b/samples/BlazorSample/Pages/Position.razor
@@ -1,0 +1,39 @@
+﻿@page "/position"
+@inject IModalService Modal
+
+<h1>Positioning the modal</h1>
+
+<hr class="mb-5" />
+
+<p>
+    The modal is shown in the center of the viewport by default. The modal can be shown
+    in different positions if needed. The positioning is flexible as it is set using
+    CSS styling.
+</p>
+
+<button @onclick="@(()=>@PositionCustom("blazored-modal-topleft"))" class="btn btn-secondary">Top left</button>
+<button @onclick="@(()=>@PositionCustom("blazored-modal-topright"))" class="btn btn-secondary">Top right</button>
+<button @onclick="PositionCenter" class="btn btn-primary">Center</button>
+<button @onclick="@(()=>@PositionCustom("blazored-modal-bottomleft"))" class="btn btn-secondary">Bottom left</button>
+<button @onclick="@(()=>@PositionCustom("blazored-modal-bottomright"))" class="btn btn-secondary">Bottom right</button>
+
+@code {
+
+    void PositionCenter()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
+    }
+
+    void PositionCustom(string position)
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+        var options = new ModalOptions() { Position = position };
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+}
+

--- a/samples/BlazorSample/Pages/YesNoPrompt.razor
+++ b/samples/BlazorSample/Pages/YesNoPrompt.razor
@@ -1,0 +1,30 @@
+﻿@inject IModalService ModalService
+
+@if (ShowForm)
+{
+    <div class="simple-form">
+        <div class="form-group">
+            Are you sure you want to delete the record?
+        </div>
+
+        <button @onclick="Yes" class="btn btn-outline-danger">Delete</button>
+        <button @onclick="No" class="btn btn-primary">Cancel</button>
+    </div>
+}
+
+@code {
+
+    [CascadingParameter] ModalParameters Parameters { get; set; }
+    bool ShowForm { get; set; } = true;
+
+    void Yes()
+    {
+        ModalService.Close(ModalResult.Ok($"The user said 'Yes'"));
+    }
+
+    void No()
+    {
+        ModalService.Close(ModalResult.Cancel());
+    }
+
+}

--- a/samples/BlazorSample/Shared/CustomModalLayout.razor
+++ b/samples/BlazorSample/Shared/CustomModalLayout.razor
@@ -1,0 +1,17 @@
+﻿@inherits LayoutComponentBase
+
+<BlazoredModal Style="blazored-custom-modal"/>
+
+<div class="sidebar">
+    <NavMenu />
+</div>
+
+<div class="main">
+    <div class="top-row px-4">
+        <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
+    </div>
+
+    <div class="content px-4">
+        @Body
+    </div>
+</div>

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -20,6 +20,9 @@
             <NavLink class="nav-link" href="/backgroundcancel" Match="NavLinkMatch.All">
                 <span class="oi oi-browser" aria-hidden="true"></span> Background click
             </NavLink>
+            <NavLink class="nav-link" href="/position" Match="NavLinkMatch.All">
+                <span class="oi oi-grid-three-up" aria-hidden="true"></span> Position
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -8,8 +8,11 @@
 <div class=@(collapseNavMenu ? "collapse" : null) @onclick=@ToggleNavMenu>
     <ul class="nav flex-column">
         <li class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match=NavLinkMatch.All>
+            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="oi oi-home" aria-hidden="true"></span> Home
+            </NavLink>
+            <NavLink class="nav-link" href="/custom" Match="NavLinkMatch.All">
+                <span class="oi oi-wrench" aria-hidden="true"></span> Custom styling
             </NavLink>
         </li>
     </ul>

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -17,6 +17,9 @@
             <NavLink class="nav-link" href="/closebutton" Match="NavLinkMatch.All">
                 <span class="oi oi-x" aria-hidden="true"></span> Close button
             </NavLink>
+            <NavLink class="nav-link" href="/backgroundcancel" Match="NavLinkMatch.All">
+                <span class="oi oi-browser" aria-hidden="true"></span> Background click
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -14,6 +14,9 @@
             <NavLink class="nav-link" href="/custom" Match="NavLinkMatch.All">
                 <span class="oi oi-eye" aria-hidden="true"></span> Styling
             </NavLink>
+            <NavLink class="nav-link" href="/closebutton" Match="NavLinkMatch.All">
+                <span class="oi oi-x" aria-hidden="true"></span> Close button
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -12,7 +12,7 @@
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
             <NavLink class="nav-link" href="/custom" Match="NavLinkMatch.All">
-                <span class="oi oi-wrench" aria-hidden="true"></span> Custom styling
+                <span class="oi oi-eye" aria-hidden="true"></span> Styling
             </NavLink>
         </li>
     </ul>

--- a/samples/BlazorSample/wwwroot/css/site.css
+++ b/samples/BlazorSample/wwwroot/css/site.css
@@ -125,11 +125,28 @@ app {
 .blazored-custom-modal {
     display: flex;
     flex-direction: column;
-    width: 80vw;
-    background-color: #d8d8d8;
+    width: 60vw;
+    height: 60vh;
+    background-color: #fafafa;
+    border-radius: 12px;
+    border: 1px solid #fff;
+    padding: 0.5rem;
+    z-index: 102;
+    box-shadow: 0 2px 2px rgba(0,0,0,.75);
+}
+
+.blazored-prompt-modal {
+    display: flex;
+    flex-direction: column;
+    width: 600px;
+    background-color: #fefefe;
     border-radius: 4px;
     border: 1px solid #fff;
     padding: 0.5rem;
     z-index: 102;
     box-shadow: 0 2px 2px rgba(0,0,0,.75);
+}
+
+.blazored-prompt-modal .blazored-modal-header {
+    display: none;
 }

--- a/samples/BlazorSample/wwwroot/css/site.css
+++ b/samples/BlazorSample/wwwroot/css/site.css
@@ -121,3 +121,15 @@ app {
         display: block;
     }
 }
+
+.blazored-custom-modal {
+    display: flex;
+    flex-direction: column;
+    width: 80vw;
+    background-color: #d8d8d8;
+    border-radius: 4px;
+    border: 1px solid #fff;
+    padding: 0.5rem;
+    z-index: 102;
+    box-shadow: 0 2px 2px rgba(0,0,0,.75);
+}

--- a/samples/BlazorSample/wwwroot/css/site.css
+++ b/samples/BlazorSample/wwwroot/css/site.css
@@ -125,5 +125,5 @@ app {
 .blazored-custom-modal {
     width: 80vw;
     height: 60vh;
-    background-color: #d8d8d8 !important;
+    background-color: #d8d8d8;
 }

--- a/samples/BlazorSample/wwwroot/css/site.css
+++ b/samples/BlazorSample/wwwroot/css/site.css
@@ -123,7 +123,13 @@ app {
 }
 
 .blazored-custom-modal {
+    display: flex;
+    flex-direction: column;
     width: 80vw;
-    height: 60vh;
     background-color: #d8d8d8;
+    border-radius: 4px;
+    border: 1px solid #fff;
+    padding: 0.5rem;
+    z-index: 102;
+    box-shadow: 0 2px 2px rgba(0,0,0,.75);
 }

--- a/samples/BlazorSample/wwwroot/css/site.css
+++ b/samples/BlazorSample/wwwroot/css/site.css
@@ -123,13 +123,7 @@ app {
 }
 
 .blazored-custom-modal {
-    display: flex;
-    flex-direction: column;
     width: 80vw;
-    background-color: #d8d8d8;
-    border-radius: 4px;
-    border: 1px solid #fff;
-    padding: 0.5rem;
-    z-index: 102;
-    box-shadow: 0 2px 2px rgba(0,0,0,.75);
+    height: 60vh;
+    background-color: #d8d8d8 !important;
 }

--- a/samples/ServerSideblazor/Pages/BackGroundCancel.razor
+++ b/samples/ServerSideblazor/Pages/BackGroundCancel.razor
@@ -1,0 +1,35 @@
+﻿@page "/backgroundcancel"
+@inject IModalService Modal
+
+<h1>Click background to cancel</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A modal is cancelled by default if the user clicks outside the modal. This behavior can
+    be disabled.
+</p>
+<button @onclick="BackgroundCancelEnabled" class="btn btn-primary">Cancellation enabled</button>
+<button @onclick="BackgroundCancelDisabled" class="btn btn-secondary">Cancellation disabled</button>
+
+@code {
+
+    void BackgroundCancelEnabled()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+        var options = new ModalOptions() { DisableBackgroundCancel = false };
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+
+    void BackgroundCancelDisabled()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+        var options = new ModalOptions() { DisableBackgroundCancel = true };
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+}
+

--- a/samples/ServerSideblazor/Pages/CustomStyle.razor
+++ b/samples/ServerSideblazor/Pages/CustomStyle.razor
@@ -1,0 +1,60 @@
+﻿@page "/custom"
+@inject IModalService Modal
+@layout CustomModalLayout
+
+<h1>Blazored Modal Sample with Custom Styling</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A custom style can be set globally by adding the <var>Style</var> property on <code>BlazoredModal</code> like this:
+</p>
+<button @onclick="ShowModal" class="btn btn-primary">Show custom Modal</button>
+
+<hr class="mb-5" />
+
+<p>
+    A custom style can also be set as a parameter on the <code>Modal.Show()</code> method.
+</p>
+
+<button @onclick="@(ShowModalCustomStyle)" class="btn btn-primary">Show Modal styled as a prompt</button>
+
+@code {
+
+    void ShowModal()
+    {
+        var parameters = new ModalParameters();
+
+        parameters.Add("FormId", 11);
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
+    }
+
+    void ShowModalCustomStyle()
+    {
+        var parameters = new ModalParameters();
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show("Delete record?", typeof(YesNoPrompt), "blazored-prompt-modal");
+    }
+
+
+    void ModalClosed(ModalResult modalResult)
+    {
+        Console.WriteLine("Modal has closed");
+
+        if (modalResult.Cancelled)
+        {
+            Console.WriteLine("Modal was Cancelled");
+        }
+        else
+        {
+            Console.WriteLine(modalResult.Data.ToString());
+        }
+
+        Modal.OnClose -= ModalClosed;
+    }
+
+}
+

--- a/samples/ServerSideblazor/Pages/CustomStyle.razor
+++ b/samples/ServerSideblazor/Pages/CustomStyle.razor
@@ -34,9 +34,10 @@
     void ShowModalCustomStyle()
     {
         var parameters = new ModalParameters();
+        var options = new ModalOptions() { Style = "blazored-prompt-modal" };
 
         Modal.OnClose += ModalClosed;
-        Modal.Show("Delete record?", typeof(YesNoPrompt), "blazored-prompt-modal");
+        Modal.Show("Delete record?", typeof(YesNoPrompt), options);
     }
 
 

--- a/samples/ServerSideblazor/Pages/HideCloseButton.razor
+++ b/samples/ServerSideblazor/Pages/HideCloseButton.razor
@@ -1,0 +1,36 @@
+﻿@page "/closebutton"
+@inject IModalService Modal
+
+<h1>Hiding the modal close button</h1>
+
+<hr class="mb-5" />
+
+<p>
+    Blazored.Modal shows a close button in the modal by default. The button can be hidden if you
+    prefer to handle closing the modal yourself.
+</p>
+
+<button @onclick="CloseButtonShown" class="btn btn-primary">Show the close button</button>
+<button @onclick="CloseButtonHidden" class="btn btn-secondary">Hide the close button</button>
+
+@code {
+
+    void CloseButtonShown()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        var options = new ModalOptions() { HideCloseButton = false };
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+
+    void CloseButtonHidden()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        var options = new ModalOptions() { HideCloseButton = true };
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+}
+

--- a/samples/ServerSideblazor/Pages/Index.razor
+++ b/samples/ServerSideblazor/Pages/Index.razor
@@ -6,7 +6,6 @@
 <hr class="mb-5" />
 
 <button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
-<button @onclick="@(ShowModalCustomStyle)" class="btn btn-outline-primary">Show Modal using custom style</button>
 
 @code {
 
@@ -19,17 +18,6 @@
         Modal.OnClose += ModalClosed;
         Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
     }
-
-    void ShowModalCustomStyle()
-    {
-        var parameters = new ModalParameters();
-
-        parameters.Add("FormId", 11);
-
-        Modal.OnClose += ModalClosed;
-        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, "blazored-custom-modal");
-    }
-
 
     void ModalClosed(ModalResult modalResult)
     {

--- a/samples/ServerSideblazor/Pages/Index.razor
+++ b/samples/ServerSideblazor/Pages/Index.razor
@@ -6,6 +6,7 @@
 <hr class="mb-5" />
 
 <button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
+<button @onclick="@(ShowModalCustomStyle)" class="btn btn-outline-primary">Show Modal using custom style</button>
 
 @code {
 
@@ -18,6 +19,17 @@
         Modal.OnClose += ModalClosed;
         Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
     }
+
+    void ShowModalCustomStyle()
+    {
+        var parameters = new ModalParameters();
+
+        parameters.Add("FormId", 11);
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, "blazored-custom-modal");
+    }
+
 
     void ModalClosed(ModalResult modalResult)
     {

--- a/samples/ServerSideblazor/Pages/Index.razor
+++ b/samples/ServerSideblazor/Pages/Index.razor
@@ -5,6 +5,11 @@
 
 <hr class="mb-5" />
 
+<p>
+    This example shows Blazored.Modal's default behavior, including opening a modal with
+    parameters and returning a result.
+</p>
+
 <button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
 
 @code {

--- a/samples/ServerSideblazor/Pages/Index.razor
+++ b/samples/ServerSideblazor/Pages/Index.razor
@@ -12,7 +12,6 @@
     void ShowModal()
     {
         var parameters = new ModalParameters();
-
         parameters.Add("FormId", 11);
 
         Modal.OnClose += ModalClosed;

--- a/samples/ServerSideblazor/Pages/Position.razor
+++ b/samples/ServerSideblazor/Pages/Position.razor
@@ -1,0 +1,39 @@
+﻿@page "/position"
+@inject IModalService Modal
+
+<h1>Positioning the modal</h1>
+
+<hr class="mb-5" />
+
+<p>
+    The modal is shown in the center of the viewport by default. The modal can be shown
+    in different positions if needed. The positioning is flexible as it is set using
+    CSS styling.
+</p>
+
+<button @onclick="@(()=>@PositionCustom("blazored-modal-topleft"))" class="btn btn-secondary">Top left</button>
+<button @onclick="@(()=>@PositionCustom("blazored-modal-topright"))" class="btn btn-secondary">Top right</button>
+<button @onclick="PositionCenter" class="btn btn-primary">Center</button>
+<button @onclick="@(()=>@PositionCustom("blazored-modal-bottomleft"))" class="btn btn-secondary">Bottom left</button>
+<button @onclick="@(()=>@PositionCustom("blazored-modal-bottomright"))" class="btn btn-secondary">Bottom right</button>
+
+@code {
+
+    void PositionCenter()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters);
+    }
+
+    void PositionCustom(string position)
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+        var options = new ModalOptions() { Position = position };
+
+        Modal.Show("Sign Up Form", typeof(SignUpForm), parameters, options);
+    }
+}
+

--- a/samples/ServerSideblazor/Pages/YesNoPrompt.razor
+++ b/samples/ServerSideblazor/Pages/YesNoPrompt.razor
@@ -1,0 +1,30 @@
+﻿@inject IModalService ModalService
+
+@if (ShowForm)
+{
+    <div class="simple-form">
+        <div class="form-group">
+            Are you sure you want to delete the record?
+        </div>
+
+        <button @onclick="Yes" class="btn btn-outline-danger">Delete</button>
+        <button @onclick="No" class="btn btn-primary">Cancel</button>
+    </div>
+}
+
+@code {
+
+    [CascadingParameter] ModalParameters Parameters { get; set; }
+    bool ShowForm { get; set; } = true;
+
+    void Yes()
+    {
+        ModalService.Close(ModalResult.Ok($"The user said 'Yes'"));
+    }
+
+    void No()
+    {
+        ModalService.Close(ModalResult.Cancel());
+    }
+
+}

--- a/samples/ServerSideblazor/Shared/CustomModalLayout.razor
+++ b/samples/ServerSideblazor/Shared/CustomModalLayout.razor
@@ -1,0 +1,17 @@
+﻿@inherits LayoutComponentBase
+
+<BlazoredModal Style="blazored-custom-modal"/>
+
+<div class="sidebar">
+    <NavMenu />
+</div>
+
+<div class="main">
+    <div class="top-row px-4">
+        <a href="https://docs.microsoft.com/en-us/aspnet/" target="_blank">About</a>
+    </div>
+
+    <div class="content px-4">
+        @Body
+    </div>
+</div>

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -20,6 +20,9 @@
             <NavLink class="nav-link" href="/backgroundcancel" Match="NavLinkMatch.All">
                 <span class="oi oi-browser" aria-hidden="true"></span> Background click
             </NavLink>
+            <NavLink class="nav-link" href="/position" Match="NavLinkMatch.All">
+                <span class="oi oi-grid-three-up" aria-hidden="true"></span> Position
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -17,6 +17,9 @@
             <NavLink class="nav-link" href="/closebutton" Match="NavLinkMatch.All">
                 <span class="oi oi-x" aria-hidden="true"></span> Close button
             </NavLink>
+            <NavLink class="nav-link" href="/backgroundcancel" Match="NavLinkMatch.All">
+                <span class="oi oi-browser" aria-hidden="true"></span> Background click
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -11,6 +11,9 @@
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
+            <NavLink class="nav-link" href="/custom" Match="NavLinkMatch.All">
+                <span class="oi oi-wrench" aria-hidden="true"></span> Custom styling
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -14,6 +14,9 @@
             <NavLink class="nav-link" href="/custom" Match="NavLinkMatch.All">
                 <span class="oi oi-eye" aria-hidden="true"></span> Styling
             </NavLink>
+            <NavLink class="nav-link" href="/closebutton" Match="NavLinkMatch.All">
+                <span class="oi oi-x" aria-hidden="true"></span> Close button
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -12,7 +12,7 @@
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
             <NavLink class="nav-link" href="/custom" Match="NavLinkMatch.All">
-                <span class="oi oi-wrench" aria-hidden="true"></span> Custom styling
+                <span class="oi oi-eye" aria-hidden="true"></span> Styling
             </NavLink>
         </li>
     </ul>

--- a/samples/ServerSideblazor/wwwroot/css/site.css
+++ b/samples/ServerSideblazor/wwwroot/css/site.css
@@ -150,13 +150,7 @@ app {
 }
 
 .blazored-custom-modal {
-    display: flex;
-    flex-direction: column;
     width: 80vw;
+    height: 60vh;
     background-color: #d8d8d8;
-    border-radius: 4px;
-    border: 1px solid #fff;
-    padding: 0.5rem;
-    z-index: 102;
-    box-shadow: 0 2px 2px rgba(0,0,0,.75);
 }

--- a/samples/ServerSideblazor/wwwroot/css/site.css
+++ b/samples/ServerSideblazor/wwwroot/css/site.css
@@ -152,11 +152,28 @@ app {
 .blazored-custom-modal {
     display: flex;
     flex-direction: column;
-    width: 80vw;
-    background-color: #d8d8d8;
+    width: 60vw;
+    height: 60vh;
+    background-color: #fafafa;
+    border-radius: 12px;
+    border: 1px solid #fff;
+    padding: 0.5rem;
+    z-index: 102;
+    box-shadow: 0 2px 2px rgba(0,0,0,.75);
+}
+
+.blazored-prompt-modal {
+    display: flex;
+    flex-direction: column;
+    width: 600px;
+    background-color: #fefefe;
     border-radius: 4px;
     border: 1px solid #fff;
     padding: 0.5rem;
     z-index: 102;
     box-shadow: 0 2px 2px rgba(0,0,0,.75);
+}
+
+.blazored-prompt-modal .blazored-modal-header {
+    display: none;
 }

--- a/samples/ServerSideblazor/wwwroot/css/site.css
+++ b/samples/ServerSideblazor/wwwroot/css/site.css
@@ -150,7 +150,13 @@ app {
 }
 
 .blazored-custom-modal {
+    display: flex;
+    flex-direction: column;
     width: 80vw;
-    height: 60vh;
     background-color: #d8d8d8;
+    border-radius: 4px;
+    border: 1px solid #fff;
+    padding: 0.5rem;
+    z-index: 102;
+    box-shadow: 0 2px 2px rgba(0,0,0,.75);
 }

--- a/samples/ServerSideblazor/wwwroot/css/site.css
+++ b/samples/ServerSideblazor/wwwroot/css/site.css
@@ -148,3 +148,15 @@ app {
         display: block;
     }
 }
+
+.blazored-custom-modal {
+    display: flex;
+    flex-direction: column;
+    width: 80vw;
+    background-color: #d8d8d8;
+    border-radius: 4px;
+    border: 1px solid #fff;
+    padding: 0.5rem;
+    z-index: 102;
+    box-shadow: 0 2px 2px rgba(0,0,0,.75);
+}

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -8,7 +8,7 @@
     <div class="@ComponentStyle">
         <div class="blazored-modal-header">
             <h3 class="blazored-modal-title">@Title</h3>
-            @if (!HideCloseButton)
+            @if (!ComponentHideCloseButton)
             {
                 <button type="button" class="blazored-modal-close" @onclick="@(() => ModalService.Cancel())">
                     <span>&times;</span>

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -5,7 +5,7 @@
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="blazored-modal @Style">
+    <div class="@Style">
         <div class="blazored-modal-header">
             <h3 class="blazored-modal-title">@Title</h3>
             @if (!HideCloseButton)

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -5,7 +5,7 @@
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="@Style">
+    <div class="blazored-modal @Style">
         <div class="blazored-modal-header">
             <h3 class="blazored-modal-title">@Title</h3>
             @if (!HideCloseButton)

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -5,7 +5,7 @@
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="@Style">
+    <div class="@ComponentStyle">
         <div class="blazored-modal-header">
             <h3 class="blazored-modal-title">@Title</h3>
             @if (!HideCloseButton)

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -5,7 +5,7 @@
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="blazored-modal">
+    <div class="@Style">
         <div class="blazored-modal-header">
             <h3 class="blazored-modal-title">@Title</h3>
             @if (!HideCloseButton)

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -1,24 +1,26 @@
 ﻿@inherits BlazoredModalBase
 @using Microsoft.AspNetCore.Components.Web
 
-<div class="blazored-modal-container @(IsVisible ? "blazored-modal-active" : string.Empty)">
+<div class="blazored-modal-container @ComponentPosition @(IsVisible ? "blazored-modal-active" : string.Empty)">
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="@ComponentStyle">
-        <div class="blazored-modal-header">
-            <h3 class="blazored-modal-title">@Title</h3>
-            @if (!ComponentHideCloseButton)
-            {
-                <button type="button" class="blazored-modal-close" @onclick="@(() => ModalService.Cancel())">
-                    <span>&times;</span>
-                </button>
-            }
-        </div>
-        <div class="blazored-modal-content">
-            <CascadingValue Value="@Parameters">
-                @Content
-            </CascadingValue>
+    <div class="blazored-modal-wrapper">
+        <div class="@ComponentStyle">
+            <div class="blazored-modal-header">
+                <h3 class="blazored-modal-title">@Title</h3>
+                @if (!ComponentHideCloseButton)
+                {
+                    <button type="button" class="blazored-modal-close" @onclick="@(() => ModalService.Cancel())">
+                        <span>&times;</span>
+                    </button>
+                }
+            </div>
+            <div class="blazored-modal-content">
+                <CascadingValue Value="@Parameters">
+                    @Content
+                </CascadingValue>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -6,13 +6,16 @@ namespace Blazored.Modal
 {
     public class BlazoredModalBase : ComponentBase, IDisposable
     {
+        const string DefaultStyle = "blazored-modal";
+
         [Inject] protected IModalService ModalService { get; set; }
 
         [Parameter] public bool HideCloseButton { get; set; }
         [Parameter] public bool DisableBackgroundCancel { get; set; }
-        [Parameter] public string Style { get; set; } = "blazored-modal";
+        [Parameter] public string Style { get; set; }
 
         protected string ComponentStyle { get; set; }
+        protected ModalOptions Options { get; set; }
         protected bool IsVisible { get; set; }
         protected string Title { get; set; }
         protected RenderFragment Content { get; set; }
@@ -24,12 +27,15 @@ namespace Blazored.Modal
             ModalService.OnClose += CloseModal;
         }
 
-        public void ShowModal(string title, RenderFragment content, ModalParameters parameters, string style)
+        public void ShowModal(string title, RenderFragment content, ModalParameters parameters, ModalOptions options)
         {
             Title = title;
             Content = content;
             Parameters = parameters;
-            ComponentStyle = string.IsNullOrWhiteSpace(style) ? Style : style;
+
+            ComponentStyle = string.IsNullOrWhiteSpace(options.Style) ? Style : options.Style;
+            if (string.IsNullOrWhiteSpace(ComponentStyle))
+                ComponentStyle = DefaultStyle;
 
             IsVisible = true;
             StateHasChanged();

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -28,7 +28,7 @@ namespace Blazored.Modal
             Title = title;
             Content = content;
             Parameters = parameters;
-            Style = $"{style}";
+            Style = string.IsNullOrWhiteSpace(style) ? "blazored-modal" : style;
 
             IsVisible = true;
             StateHasChanged();

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -38,21 +38,7 @@ namespace Blazored.Modal
             Content = content;
             Parameters = parameters;
 
-            ComponentHideCloseButton = HideCloseButton;
-            if (options.HideCloseButton.HasValue)
-                ComponentHideCloseButton = options.HideCloseButton.Value;
-
-            ComponentDisableBackgroundCancel = DisableBackgroundCancel;
-            if (options.DisableBackgroundCancel.HasValue)
-                ComponentDisableBackgroundCancel = options.DisableBackgroundCancel.Value;
-
-            ComponentPosition = string.IsNullOrWhiteSpace(options.Position) ? Position : options.Position;
-            if (string.IsNullOrWhiteSpace(ComponentPosition))
-                ComponentPosition = DefaultPosition;
-
-            ComponentStyle = string.IsNullOrWhiteSpace(options.Style) ? Style : options.Style;
-            if (string.IsNullOrWhiteSpace(ComponentStyle))
-                ComponentStyle = DefaultStyle;
+            SetModalOptions(options);
 
             IsVisible = true;
             StateHasChanged();
@@ -79,6 +65,25 @@ namespace Blazored.Modal
         {
             ((ModalService)ModalService).OnShow -= ShowModal;
             ModalService.OnClose -= CloseModal;
+        }
+
+        private void SetModalOptions(ModalOptions options)
+        {
+            ComponentHideCloseButton = HideCloseButton;
+            if (options.HideCloseButton.HasValue)
+                ComponentHideCloseButton = options.HideCloseButton.Value;
+
+            ComponentDisableBackgroundCancel = DisableBackgroundCancel;
+            if (options.DisableBackgroundCancel.HasValue)
+                ComponentDisableBackgroundCancel = options.DisableBackgroundCancel.Value;
+
+            ComponentPosition = string.IsNullOrWhiteSpace(options.Position) ? Position : options.Position;
+            if (string.IsNullOrWhiteSpace(ComponentPosition))
+                ComponentPosition = DefaultPosition;
+
+            ComponentStyle = string.IsNullOrWhiteSpace(options.Style) ? Style : options.Style;
+            if (string.IsNullOrWhiteSpace(ComponentStyle))
+                ComponentStyle = DefaultStyle;
         }
     }
 }

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -14,6 +14,7 @@ namespace Blazored.Modal
         [Parameter] public bool DisableBackgroundCancel { get; set; }
         [Parameter] public string Style { get; set; }
 
+        protected bool ComponentDisableBackgroundCancel { get; set; }
         protected bool ComponentHideCloseButton { get; set; }
         protected string ComponentStyle { get; set; }
         protected ModalOptions Options { get; set; }
@@ -41,7 +42,11 @@ namespace Blazored.Modal
             ComponentHideCloseButton = HideCloseButton;
             if (options.HideCloseButton.HasValue)
                 ComponentHideCloseButton = options.HideCloseButton.Value;
-            
+
+            ComponentDisableBackgroundCancel = DisableBackgroundCancel;
+            if (options.DisableBackgroundCancel.HasValue)
+                ComponentDisableBackgroundCancel = options.DisableBackgroundCancel.Value;
+
             IsVisible = true;
             StateHasChanged();
         }
@@ -58,7 +63,7 @@ namespace Blazored.Modal
 
         protected void HandleBackgroundClick()
         {
-            if (DisableBackgroundCancel) return;
+            if (ComponentDisableBackgroundCancel) return;
 
             ModalService.Cancel();
         }

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -15,6 +15,7 @@ namespace Blazored.Modal
         protected string Title { get; set; }
         protected RenderFragment Content { get; set; }
         protected ModalParameters Parameters { get; set; }
+        protected string Style { get; set; }
 
         protected override void OnInitialized()
         {
@@ -22,11 +23,12 @@ namespace Blazored.Modal
             ModalService.OnClose += CloseModal;
         }
 
-        public void ShowModal(string title, RenderFragment content, ModalParameters parameters)
+        public void ShowModal(string title, RenderFragment content, ModalParameters parameters, string style)
         {
             Title = title;
             Content = content;
             Parameters = parameters;
+            Style = style ?? "blazored-modal";
 
             IsVisible = true;
             StateHasChanged();
@@ -37,6 +39,7 @@ namespace Blazored.Modal
             IsVisible = false;
             Title = "";
             Content = null;
+            Style = "";
 
             StateHasChanged();
         }

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -7,15 +7,18 @@ namespace Blazored.Modal
     public class BlazoredModalBase : ComponentBase, IDisposable
     {
         const string DefaultStyle = "blazored-modal";
+        const string DefaultPosition = "blazored-modal-center";
 
         [Inject] protected IModalService ModalService { get; set; }
 
         [Parameter] public bool HideCloseButton { get; set; }
         [Parameter] public bool DisableBackgroundCancel { get; set; }
+        [Parameter] public string Position { get; set; }
         [Parameter] public string Style { get; set; }
 
         protected bool ComponentDisableBackgroundCancel { get; set; }
         protected bool ComponentHideCloseButton { get; set; }
+        protected string ComponentPosition { get; set; }
         protected string ComponentStyle { get; set; }
         protected ModalOptions Options { get; set; }
         protected bool IsVisible { get; set; }
@@ -35,10 +38,6 @@ namespace Blazored.Modal
             Content = content;
             Parameters = parameters;
 
-            ComponentStyle = string.IsNullOrWhiteSpace(options.Style) ? Style : options.Style;
-            if (string.IsNullOrWhiteSpace(ComponentStyle))
-                ComponentStyle = DefaultStyle;
-
             ComponentHideCloseButton = HideCloseButton;
             if (options.HideCloseButton.HasValue)
                 ComponentHideCloseButton = options.HideCloseButton.Value;
@@ -46,6 +45,14 @@ namespace Blazored.Modal
             ComponentDisableBackgroundCancel = DisableBackgroundCancel;
             if (options.DisableBackgroundCancel.HasValue)
                 ComponentDisableBackgroundCancel = options.DisableBackgroundCancel.Value;
+
+            ComponentPosition = string.IsNullOrWhiteSpace(options.Position) ? Position : options.Position;
+            if (string.IsNullOrWhiteSpace(ComponentPosition))
+                ComponentPosition = DefaultPosition;
+
+            ComponentStyle = string.IsNullOrWhiteSpace(options.Style) ? Style : options.Style;
+            if (string.IsNullOrWhiteSpace(ComponentStyle))
+                ComponentStyle = DefaultStyle;
 
             IsVisible = true;
             StateHasChanged();

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -14,6 +14,7 @@ namespace Blazored.Modal
         [Parameter] public bool DisableBackgroundCancel { get; set; }
         [Parameter] public string Style { get; set; }
 
+        protected bool ComponentHideCloseButton { get; set; }
         protected string ComponentStyle { get; set; }
         protected ModalOptions Options { get; set; }
         protected bool IsVisible { get; set; }
@@ -37,6 +38,10 @@ namespace Blazored.Modal
             if (string.IsNullOrWhiteSpace(ComponentStyle))
                 ComponentStyle = DefaultStyle;
 
+            ComponentHideCloseButton = HideCloseButton;
+            if (options.HideCloseButton.HasValue)
+                ComponentHideCloseButton = options.HideCloseButton.Value;
+            
             IsVisible = true;
             StateHasChanged();
         }

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -28,7 +28,7 @@ namespace Blazored.Modal
             Title = title;
             Content = content;
             Parameters = parameters;
-            Style = style ?? "blazored-modal";
+            Style = string.IsNullOrWhitespace(Style) ? "blazored-modal" : $"blazored-model {Style}";
 
             IsVisible = true;
             StateHasChanged();

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -10,12 +10,13 @@ namespace Blazored.Modal
 
         [Parameter] public bool HideCloseButton { get; set; }
         [Parameter] public bool DisableBackgroundCancel { get; set; }
+        [Parameter] public string Style { get; set; } = "blazored-modal";
 
+        protected string ComponentStyle { get; set; }
         protected bool IsVisible { get; set; }
         protected string Title { get; set; }
         protected RenderFragment Content { get; set; }
         protected ModalParameters Parameters { get; set; }
-        protected string Style { get; set; }
 
         protected override void OnInitialized()
         {
@@ -28,7 +29,7 @@ namespace Blazored.Modal
             Title = title;
             Content = content;
             Parameters = parameters;
-            Style = string.IsNullOrWhiteSpace(style) ? "blazored-modal" : style;
+            ComponentStyle = string.IsNullOrWhiteSpace(style) ? Style : style;
 
             IsVisible = true;
             StateHasChanged();
@@ -39,7 +40,7 @@ namespace Blazored.Modal
             IsVisible = false;
             Title = "";
             Content = null;
-            Style = "";
+            ComponentStyle = "";
 
             StateHasChanged();
         }

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -28,7 +28,7 @@ namespace Blazored.Modal
             Title = title;
             Content = content;
             Parameters = parameters;
-            Style = string.IsNullOrWhitespace(Style) ? "blazored-modal" : $"blazored-model {Style}";
+            Style = string.IsNullOrWhiteSpace(Style) ? "blazored-modal" : $"blazored-model {Style}";
 
             IsVisible = true;
             StateHasChanged();

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -28,7 +28,7 @@ namespace Blazored.Modal
             Title = title;
             Content = content;
             Parameters = parameters;
-            Style = string.IsNullOrWhiteSpace(Style) ? "blazored-modal" : $"blazored-model {Style}";
+            Style = $"{style}";
 
             IsVisible = true;
             StateHasChanged();

--- a/src/Blazored.Modal/ModalOptions.cs
+++ b/src/Blazored.Modal/ModalOptions.cs
@@ -2,6 +2,7 @@
 {
     public class ModalOptions
     {
+        public bool? DisableBackgroundCancel { get; set; }
         public bool? HideCloseButton { get; set; }
         public string Style { get; set; }
     }

--- a/src/Blazored.Modal/ModalOptions.cs
+++ b/src/Blazored.Modal/ModalOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Blazored.Modal
+{
+    public class ModalOptions
+    {
+        public string Style { get; set; }
+    }
+}

--- a/src/Blazored.Modal/ModalOptions.cs
+++ b/src/Blazored.Modal/ModalOptions.cs
@@ -4,6 +4,7 @@
     {
         public bool? DisableBackgroundCancel { get; set; }
         public bool? HideCloseButton { get; set; }
+        public string Position { get; set; }
         public string Style { get; set; }
     }
 }

--- a/src/Blazored.Modal/ModalOptions.cs
+++ b/src/Blazored.Modal/ModalOptions.cs
@@ -2,6 +2,7 @@
 {
     public class ModalOptions
     {
+        public bool? HideCloseButton { get; set; }
         public string Style { get; set; }
     }
 }

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -21,8 +21,8 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="componentType">Type of component to display.</param>
-        /// <param name="style">Modal's custom CSS style selector.</param>
-        void Show(string title, Type componentType, string style);
+        /// <param name="options">Options to configure the modal.</param>
+        void Show(string title, Type componentType, ModalOptions options);
 
         /// <summary>
         /// Shows the modal using the specified <paramref name="title"/> and <paramref name="componentType"/>, 
@@ -40,8 +40,8 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="componentType">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        /// <param name="style">Modal's custom CSS style selector.</param>
-        void Show(string title, Type componentType, ModalParameters parameters, string style);
+        /// <param name="options">Options to configure the modal.</param>
+        void Show(string title, Type componentType, ModalParameters parameters, ModalOptions options);
 
         /// <summary>
         /// Cancels the modal and invokes the <see cref="OnClose"/> event.

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -17,6 +17,14 @@ namespace Blazored.Modal.Services
         void Show(string title, Type contentType);
 
         /// <summary>
+        /// Shows the modal using the specified title and component type.
+        /// </summary>
+        /// <param name="title">Modal title.</param>
+        /// <param name="componentType">Type of component to display.</param>
+        /// <param name="style">Modal's custom CSS style selector.</param>
+        void Show(string title, Type componentType, string style);
+
+        /// <summary>
         /// Shows the modal using the specified <paramref name="title"/> and <paramref name="componentType"/>, 
         /// passing the specified <paramref name="parameters"/>. 
         /// </summary>
@@ -24,6 +32,16 @@ namespace Blazored.Modal.Services
         /// <param name="componentType">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         void Show(string title, Type contentType, ModalParameters parameters);
+
+        /// <summary>
+        /// Shows the modal using the specified <paramref name="title"/> and <paramref name="componentType"/>, 
+        /// passing the specified <paramref name="parameters"/> and setting a custom CSS style. 
+        /// </summary>
+        /// <param name="title">Modal title.</param>
+        /// <param name="componentType">Type of component to display.</param>
+        /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
+        /// <param name="style">Modal's custom CSS style selector.</param>
+        void Show(string title, Type componentType, ModalParameters parameters, string style);
 
         /// <summary>
         /// Cancels the modal and invokes the <see cref="OnClose"/> event.

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -13,7 +13,7 @@ namespace Blazored.Modal.Services
         /// <summary>
         /// Internal event used to trigger the modal component to show.
         /// </summary>
-        internal event Action<string, RenderFragment, ModalParameters> OnShow;
+        internal event Action<string, RenderFragment, ModalParameters, string> OnShow;
 
         /// <summary>
         /// Shows the modal using the specified title and component type.
@@ -26,6 +26,17 @@ namespace Blazored.Modal.Services
         }
 
         /// <summary>
+        /// Shows the modal using the specified title and component type.
+        /// </summary>
+        /// <param name="title">Modal title.</param>
+        /// <param name="componentType">Type of component to display.</param>
+        /// <param name="style">Modal's custom CSS style selector.</param>
+        public void Show(string title, Type componentType, string style = "blazored-modal")
+        {
+            Show(title, componentType, new ModalParameters(), style);
+        }
+
+        /// <summary>
         /// Shows the modal using the specified <paramref name="title"/> and <paramref name="componentType"/>, 
         /// passing the specified <paramref name="parameters"/>. 
         /// </summary>
@@ -34,6 +45,19 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         public void Show(string title, Type componentType, ModalParameters parameters)
         {
+            Show(title, componentType, parameters, null);
+        }
+
+        /// <summary>
+        /// Shows the modal using the specified <paramref name="title"/> and <paramref name="componentType"/>, 
+        /// passing the specified <paramref name="parameters"/> and setting a custom CSS style. 
+        /// </summary>
+        /// <param name="title">Modal title.</param>
+        /// <param name="componentType">Type of component to display.</param>
+        /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
+        /// <param name="style">Modal's custom CSS style selector.</param>
+        public void Show(string title, Type componentType, ModalParameters parameters, string style = "blazored-modal")
+        {
             if (!typeof(ComponentBase).IsAssignableFrom(componentType))
             {
                 throw new ArgumentException($"{componentType.FullName} must be a Blazor Component");
@@ -41,7 +65,7 @@ namespace Blazored.Modal.Services
 
             var content = new RenderFragment(x => { x.OpenComponent(1, componentType); x.CloseComponent(); });
 
-            OnShow?.Invoke(title, content, parameters);
+            OnShow?.Invoke(title, content, parameters, style);
         }
 
         /// <summary>

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -31,7 +31,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="componentType">Type of component to display.</param>
         /// <param name="style">Modal's custom CSS style selector.</param>
-        public void Show(string title, Type componentType, string style = "blazored-modal")
+        public void Show(string title, Type componentType, string style)
         {
             Show(title, componentType, new ModalParameters(), style);
         }
@@ -56,7 +56,7 @@ namespace Blazored.Modal.Services
         /// <param name="componentType">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="style">Modal's custom CSS style selector.</param>
-        public void Show(string title, Type componentType, ModalParameters parameters, string style = "blazored-modal")
+        public void Show(string title, Type componentType, ModalParameters parameters, string style)
         {
             if (!typeof(ComponentBase).IsAssignableFrom(componentType))
             {

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -13,7 +13,7 @@ namespace Blazored.Modal.Services
         /// <summary>
         /// Internal event used to trigger the modal component to show.
         /// </summary>
-        internal event Action<string, RenderFragment, ModalParameters, string> OnShow;
+        internal event Action<string, RenderFragment, ModalParameters, ModalOptions> OnShow;
 
         /// <summary>
         /// Shows the modal using the specified title and component type.
@@ -22,7 +22,7 @@ namespace Blazored.Modal.Services
         /// <param name="componentType">Type of component to display.</param>
         public void Show(string title, Type componentType)
         {
-            Show(title, componentType, new ModalParameters());
+            Show(title, componentType, new ModalParameters(), new ModalOptions());
         }
 
         /// <summary>
@@ -30,10 +30,10 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="componentType">Type of component to display.</param>
-        /// <param name="style">Modal's custom CSS style selector.</param>
-        public void Show(string title, Type componentType, string style)
+        /// <param name="options">Options to configure the modal.</param>
+        public void Show(string title, Type componentType, ModalOptions options)
         {
-            Show(title, componentType, new ModalParameters(), style);
+            Show(title, componentType, new ModalParameters(), options);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         public void Show(string title, Type componentType, ModalParameters parameters)
         {
-            Show(title, componentType, parameters, null);
+            Show(title, componentType, parameters, new ModalOptions());
         }
 
         /// <summary>
@@ -55,8 +55,8 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="componentType">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        /// <param name="style">Modal's custom CSS style selector.</param>
-        public void Show(string title, Type componentType, ModalParameters parameters, string style)
+        /// <param name="options">Options to configure the modal.</param>
+        public void Show(string title, Type componentType, ModalParameters parameters, ModalOptions options)
         {
             if (!typeof(ComponentBase).IsAssignableFrom(componentType))
             {
@@ -65,7 +65,7 @@ namespace Blazored.Modal.Services
 
             var content = new RenderFragment(x => { x.OpenComponent(1, componentType); x.CloseComponent(); });
 
-            OnShow?.Invoke(title, content, parameters, style);
+            OnShow?.Invoke(title, content, parameters, options);
         }
 
         /// <summary>

--- a/src/Blazored.Modal/wwwroot/blazored-modal.css
+++ b/src/Blazored.Modal/wwwroot/blazored-modal.css
@@ -1,7 +1,5 @@
 ﻿.blazored-modal-container {
     display: none;
-    align-items: center;
-    justify-content: center;
     position: fixed;
     width: 100%;
     height: 100%;
@@ -29,7 +27,6 @@
     border-radius: 4px;
     border: 1px solid #fff;
     padding: 1.5rem;
-    z-index: 102;
     box-shadow: 0 2px 2px rgba(0,0,0,.25);
 }
 
@@ -53,4 +50,37 @@
     cursor: pointer;
     font-size: 1.5rem;
     font-weight: bold;
+}
+
+.blazored-modal-center {
+    align-items: center;
+    justify-content: center;
+}
+
+.blazored-modal-wrapper {
+    z-index: 102;
+}
+
+.blazored-modal-topleft .blazored-modal-wrapper {
+    position: absolute;
+    top: 32px;
+    left: 32px;
+}
+
+.blazored-modal-topright .blazored-modal-wrapper {
+    position: absolute;
+    top: 32px;
+    right: 32px;
+}
+
+.blazored-modal-bottomleft .blazored-modal-wrapper {
+    position: absolute;
+    bottom: 32px;
+    left: 32px;
+}
+
+.blazored-modal-bottomright .blazored-modal-wrapper {
+    position: absolute;
+    bottom: 32px;
+    right: 32px;
 }


### PR DESCRIPTION
Adds a parameter to the `Modal.Show()` method, allowing the developer to specify a custom style for the modal.

Fixes #43