### PR TITLE
Add parameter to ModalResult that identifies the modal which caused the close event

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If you need to pass values to the component you are displaying in the modal, the
 
 ### Modal Closed Event
 
-If you need to know when the modal has closed, for example to trigger an update of data. The modal service exposes a `OnClose` event which returns a `ModalResult` type. This type is used to identify how the modal was closed. If the modal was cancelled you can return `ModalResult.Cancelled()`. If you want to return a object from your modal you can return `ModalResult.Ok(myResultObject)` which can be accessed via the `ModalResult.Data` property. There is also a `ModalResult.DataType` property which contains the type of the data property, if required.
+If you need to know when the modal has closed, for example to trigger an update of data. The modal service exposes a `OnClose` event which returns a `ModalResult` type. This type is used to identify how the modal was closed. If the modal was cancelled you can return `ModalResult.Cancelled()`. If you want to return a object from your modal you can return `ModalResult.Ok(myResultObject)` which can be accessed via the `ModalResult.Data` property. There is also a `ModalResult.DataType` property which contains the type of the data property, if required. The `ModalResult` also contains the `ModalResult.ModalType` property, which can be used to identify which modal caused the `OnClose` event to fire. This property will be equal to the type used in the `Modal.Show` call. In the example below, it would thus be equal to the type `Movies`.
 
 ```html
 @page "/"
@@ -194,7 +194,9 @@ If you need to know when the modal has closed, for example to trigger an update 
         {
             Console.WriteLine(modalResult.Data);
         }
-
+        Console.Write("Modal was closed by ");
+        Console.WriteLine(modalResult.ModalType);
+        
         Modal.OnClose -= ModalClosed;
     }
 

--- a/samples/BlazorSample/Pages/CloseSource.razor
+++ b/samples/BlazorSample/Pages/CloseSource.razor
@@ -1,0 +1,74 @@
+﻿@page "/closesource"
+@inject IModalService Modal
+
+<h1>Determine which modal was closed</h1>
+
+<hr class="mb-5" />
+
+<p>
+    This example shows how to determine which modal caused the ModalClosed event.
+</p>
+
+@if (_lastClosedModalType != null)
+{
+<p class="alert-success">Last closed modal was of type <strong>@_lastClosedModalType.FullName</strong> which means it was <strong>@_lastClosedModal</strong></p>
+}
+
+<button @onclick="ShowModal1" class="btn btn-primary">Show Modal 1</button>
+<button @onclick="ShowModal2" class="btn btn-primary">Show Modal 2</button>
+
+@code {
+    private string _lastClosedModal = "";
+    private Type _lastClosedModalType = null;
+
+    void ShowModal1()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show<SignUpForm>("Sign Up Form", parameters);
+    }
+
+    void ShowModal2()
+    {
+        var parameters = new ModalParameters();
+        var options = new ModalOptions() { Style = "blazored-prompt-modal" };
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show<YesNoPrompt>("Delete record?", options);
+    }
+
+    void ModalClosed(ModalResult modalResult)
+    {
+        Console.WriteLine("Modal has closed");
+
+        if (modalResult.Cancelled)
+        {
+            Console.WriteLine("Modal was Cancelled");
+        }
+        else
+        {
+            Console.WriteLine(modalResult.Data.ToString());
+        }
+        _lastClosedModalType = modalResult.ModalType;
+        if (_lastClosedModalType == typeof(SignUpForm))
+        {
+            _lastClosedModal = "Modal 1";
+        }
+        else if(_lastClosedModalType == typeof(YesNoPrompt))
+        {
+            _lastClosedModal = "Modal 2";
+        }
+        else
+        {
+            _lastClosedModal = "Unknown";
+        }
+        StateHasChanged();
+
+
+        Modal.OnClose -= ModalClosed;
+    }
+
+}
+

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -23,6 +23,9 @@
             <NavLink class="nav-link" href="/position" Match="NavLinkMatch.All">
                 <span class="oi oi-grid-three-up" aria-hidden="true"></span> Position
             </NavLink>
+            <NavLink class="nav-link" href="/closesource" Match="NavLinkMatch.All">
+                <span class="oi oi-code" aria-hidden="true"></span> Close Event ModalType
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/ServerSideblazor/Pages/CloseSource.razor
+++ b/samples/ServerSideblazor/Pages/CloseSource.razor
@@ -1,0 +1,74 @@
+﻿@page "/closesource"
+@inject IModalService Modal
+
+<h1>Determine which modal was closed</h1>
+
+<hr class="mb-5" />
+
+<p>
+    This example shows how to determine which modal caused the ModalClosed event.
+</p>
+
+@if (_lastClosedModalType != null)
+{
+<p class="alert-success">Last closed modal was of type <strong>@_lastClosedModalType.FullName</strong> which means it was <strong>@_lastClosedModal</strong></p>
+}
+
+<button @onclick="ShowModal1" class="btn btn-primary">Show Modal 1</button>
+<button @onclick="ShowModal2" class="btn btn-primary">Show Modal 2</button>
+
+@code {
+    private string _lastClosedModal = "";
+    private Type _lastClosedModalType = null;
+
+    void ShowModal1()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 11);
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show<SignUpForm>("Sign Up Form", parameters);
+    }
+
+    void ShowModal2()
+    {
+        var parameters = new ModalParameters();
+        var options = new ModalOptions() { Style = "blazored-prompt-modal" };
+
+        Modal.OnClose += ModalClosed;
+        Modal.Show<YesNoPrompt>("Delete record?", options);
+    }
+
+    void ModalClosed(ModalResult modalResult)
+    {
+        Console.WriteLine("Modal has closed");
+
+        if (modalResult.Cancelled)
+        {
+            Console.WriteLine("Modal was Cancelled");
+        }
+        else
+        {
+            Console.WriteLine(modalResult.Data.ToString());
+        }
+        _lastClosedModalType = modalResult.ModalType;
+        if (_lastClosedModalType == typeof(SignUpForm))
+        {
+            _lastClosedModal = "Modal 1";
+        }
+        else if(_lastClosedModalType == typeof(YesNoPrompt))
+        {
+            _lastClosedModal = "Modal 2";
+        }
+        else
+        {
+            _lastClosedModal = "Unknown";
+        }
+        StateHasChanged();
+
+
+        Modal.OnClose -= ModalClosed;
+    }
+
+}
+

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -23,6 +23,9 @@
             <NavLink class="nav-link" href="/position" Match="NavLinkMatch.All">
                 <span class="oi oi-grid-three-up" aria-hidden="true"></span> Position
             </NavLink>
+            <NavLink class="nav-link" href="/closesource" Match="NavLinkMatch.All">
+                <span class="oi oi-code" aria-hidden="true"></span> Close Event ModalType
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/src/Blazored.Modal/Services/ModalResult.cs
+++ b/src/Blazored.Modal/Services/ModalResult.cs
@@ -7,16 +7,23 @@ namespace Blazored.Modal.Services
         public object Data { get; }
         public Type DataType { get; }
         public bool Cancelled { get; }
+        public Type ModalType { get; set; }
 
-        protected ModalResult(object data, Type resultType, bool cancelled)
+        protected ModalResult(object data, Type resultType, bool cancelled, Type modalType)
         {
             Data = data;
             DataType = resultType;
             Cancelled = cancelled;
+            ModalType = modalType;
         }
 
-        public static ModalResult Ok<T>(T result) => new ModalResult(result, typeof(T), false);
+        public static ModalResult Ok<T>(T result) => Ok(result, default);
 
-        public static ModalResult Cancel() => new ModalResult(default, typeof(object), true);
+        public static ModalResult Ok<T>(T result, Type modalType) => new ModalResult(result, typeof(T), false, modalType);
+
+        public static ModalResult Cancel() => Cancel(default);
+
+        public static ModalResult Cancel(Type modelType) => new ModalResult(default, typeof(object), true, modelType);
+
     }
 }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -20,6 +20,8 @@ namespace Blazored.Modal.Services
         /// </summary>
         internal event Action<string, RenderFragment, ModalParameters, ModalOptions> OnShow;
 
+        private Type ModalType;
+
         /// <summary>
         /// Shows the modal with the component type using the specified title.
         /// </summary>
@@ -68,6 +70,7 @@ namespace Blazored.Modal.Services
             }
 
             var content = new RenderFragment(x => { x.OpenComponent(1, typeof(T)); x.CloseComponent(); });
+            ModalType = typeof(T);
 
             OnShow?.Invoke(title, content, parameters, options);
         }
@@ -78,7 +81,7 @@ namespace Blazored.Modal.Services
         public void Cancel()
         {
             CloseModal?.Invoke();
-            OnClose?.Invoke(ModalResult.Cancel());
+            OnClose?.Invoke(ModalResult.Cancel(ModalType));
         }
 
         /// <summary>
@@ -87,6 +90,7 @@ namespace Blazored.Modal.Services
         /// <param name="modalResult"></param>
         public void Close(ModalResult modalResult)
         {
+            modalResult.ModalType = ModalType;
             CloseModal?.Invoke();
             OnClose?.Invoke(modalResult);
         }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -20,7 +20,7 @@ namespace Blazored.Modal.Services
         /// </summary>
         internal event Action<string, RenderFragment, ModalParameters, ModalOptions> OnShow;
 
-        private Type ModalType;
+        private Type _modalType;
 
         /// <summary>
         /// Shows the modal with the component type using the specified title.
@@ -70,7 +70,7 @@ namespace Blazored.Modal.Services
             }
 
             var content = new RenderFragment(x => { x.OpenComponent(1, typeof(T)); x.CloseComponent(); });
-            ModalType = typeof(T);
+            _modalType = typeof(T);
 
             OnShow?.Invoke(title, content, parameters, options);
         }
@@ -81,7 +81,7 @@ namespace Blazored.Modal.Services
         public void Cancel()
         {
             CloseModal?.Invoke();
-            OnClose?.Invoke(ModalResult.Cancel(ModalType));
+            OnClose?.Invoke(ModalResult.Cancel(_modalType));
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Blazored.Modal.Services
         /// <param name="modalResult"></param>
         public void Close(ModalResult modalResult)
         {
-            modalResult.ModalType = ModalType;
+            modalResult.ModalType = _modalType;
             CloseModal?.Invoke();
             OnClose?.Invoke(modalResult);
         }


### PR DESCRIPTION
This commit could potentially fix issue #76. I don't know if you think this is a good solution, but than at least we have a starting point. I have only made the change and not made any examples for it yet. I can do this in the future, but for now I would like to see if you like this change I made.

The type of the modal that was used to show the modal will be returned in the ModalResult of the OnClose event. This way a page that has multiple components could see which component was just closed.

Again, I am not saying this is a perfect solution, just something I thought of that could be a good idea for issue #76. Just let me know what you think.