### PR TITLE
Close Modal on Escape

### DIFF
--- a/samples/ServerSideblazor/Pages/_Host.cshtml
+++ b/samples/ServerSideblazor/Pages/_Host.cshtml
@@ -19,5 +19,6 @@
     </app>
 
     <script src="_framework/blazor.server.js"></script>
+    <script src="_content/Blazored.Modal/blazored-modal.js"></script>
 </body>
 </html>

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -1,5 +1,7 @@
 ﻿using Blazored.Modal.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using System;
 
 namespace Blazored.Modal
@@ -10,6 +12,7 @@ namespace Blazored.Modal
         const string _defaultPosition = "blazored-modal-center";
 
         [Inject] private IModalService ModalService { get; set; }
+        [Inject] private IJSRuntime JSRuntime { get; set; }
 
         [Parameter] public bool HideHeader { get; set; }
         [Parameter] public bool HideCloseButton { get; set; }
@@ -52,7 +55,15 @@ namespace Blazored.Modal
             SetModalOptions(options);
 
             IsVisible = true;
+
+            await JSRuntime.InvokeVoidAsync("blazoredModal.registerEscListener", DotNetObjectReference.Create(this));
             await InvokeAsync(StateHasChanged);
+        }
+
+        [JSInvokable]
+        public void JsInvokeCloseModal()
+        {
+            ModalService.Cancel();
         }
 
         private async void CloseModal()
@@ -62,6 +73,7 @@ namespace Blazored.Modal
             Content = null;
             ComponentStyle = "";
 
+            await JSRuntime.InvokeVoidAsync("blazoredModal.unRegisterEscListener");
             await InvokeAsync(StateHasChanged);
         }
 

--- a/src/Blazored.Modal/wwwroot/blazored-modal.js
+++ b/src/Blazored.Modal/wwwroot/blazored-modal.js
@@ -1,0 +1,22 @@
+﻿var blazoredModal = (function () {
+
+    var elementReference = null;
+
+    return {
+        registerEscListener: function (element) {
+            elementReference = element;
+            document.addEventListener('keydown', blazoredModal.onKeyDownEvent);
+        },
+
+        unRegisterEscListener: function () {
+            document.removeEventListener('keydown', blazoredModal.onKeyDownEvent);
+            elementReference = null;
+        },
+
+        onKeyDownEvent: function (args) {
+            if (elementReference != null && args.key == "Escape") {
+                elementReference.invokeMethodAsync('JsInvokeCloseModal');
+            }
+        }
+    };
+})();  

--- a/tests/src/Blazored.Modal.Tests/Assets/MockJsRuntime.cs
+++ b/tests/src/Blazored.Modal.Tests/Assets/MockJsRuntime.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.JSInterop;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Blazored.Modal.Tests.Assets
+{
+    public class MockJsRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
+        {
+            return new ValueTask<TValue>();
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object[] args)
+        {
+            return new ValueTask<TValue>();
+        }
+    }
+}

--- a/tests/src/Blazored.Modal.Tests/Assets/TestBase.cs
+++ b/tests/src/Blazored.Modal.Tests/Assets/TestBase.cs
@@ -1,5 +1,6 @@
 ﻿using Blazored.Modal.Services;
 using Microsoft.AspNetCore.Components.Testing;
+using Microsoft.JSInterop;
 
 namespace Blazored.Modal.Tests.Assets
 {
@@ -13,6 +14,7 @@ namespace Blazored.Modal.Tests.Assets
             _host = new TestHost();
             _modalService = new ModalService();
             _host.AddService<IModalService>(_modalService);
+            _host.AddService<IJSRuntime>(new MockJsRuntime());
         }
     }
 }


### PR DESCRIPTION
This pr uses javascript interop to implement #67
I assume that you don't like it - me neither!
But afaik this is the only way to implement it right now.

This is also a breaking change, because users need to include
`<script src="_content/Blazored.Modal/blazored-modal.js"></script>`

