### PR TITLE
New Close() overload

### DIFF
--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -85,6 +85,11 @@ namespace Blazored.Modal.Services
         }
 
         /// <summary>
+        /// Closes the modal and invokes the <see cref="OnClose"/> event with a default <see cref="ModalResult.Ok{T}(T)"/>.
+        /// </summary>
+        public void Close() => Close(ModalResult.Ok<object>(null));
+
+        /// <summary>
         /// Closes the modal and invokes the <see cref="OnClose"/> event with the specified <paramref name="modalResult"/>.
         /// </summary>
         /// <param name="modalResult"></param>


### PR DESCRIPTION
I think this is a good fix for #91. It also seems trivial enough that there doesn't have to be an example, but let me know if you disagree.

Like you said, the ModalResult can either just be discarded, or it can be used to determine which Modal caused the Close event.

Let me know if you agree with me.