### PR TITLE
Implemented ModalReference

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,28 +180,41 @@ If you need to know when the modal has closed, for example to trigger an update 
 
     void ShowModal()
     {
-        Modal.OnClose += ModalClosed;
-        Modal.Show<Movies>("My Movies");
-    }
-
-    void ModalClosed(ModalResult modalResult)
-    {
-        if (modalResult.Cancelled)
-        {
-            Console.WriteLine("Modal was cancelled");
-        }
-        else
-        {
-            Console.WriteLine(modalResult.Data);
-        }
-        Console.Write("Modal was closed by ");
-        Console.WriteLine(modalResult.ModalType);
-        
-        Modal.OnClose -= ModalClosed;
+        var modal = Modal.Show<Movies>("My Movies");
+		modal.Closed += (ModalResult modalResult)
+		{
+			if (modalResult.Cancelled)
+			{
+				Console.WriteLine("Modal was cancelled");
+			}
+			else
+			{
+				Console.WriteLine(modalResult.Data);
+			}
+			Console.Write("Modal was closed by ");
+			Console.WriteLine(modalResult.ModalType);
+		};
     }
 
 }
 ```
+
+### await Result - alternative to Closed Event
+```csharp
+var modal = Modal.Show<Movies>("My Movies");
+var modalResult = await modal.Result;
+if (modalResult.Cancelled)
+{
+    Console.WriteLine("Modal was cancelled");
+}
+else
+{
+    Console.WriteLine(modalResult.Data);
+}
+Console.Write("Modal was closed by ");
+Console.WriteLine(modalResult.ModalType);
+```
+
 
 ### Customizing the modal
 

--- a/samples/BlazorSample/Pages/CloseSource.razor
+++ b/samples/BlazorSample/Pages/CloseSource.razor
@@ -11,7 +11,7 @@
 
 @if (_lastClosedModalType != null)
 {
-<p class="alert-success">Last closed modal was of type <strong>@_lastClosedModalType.FullName</strong> which means it was <strong>@_lastClosedModal</strong></p>
+    <p class="alert-success">Last closed modal was of type <strong>@_lastClosedModalType.FullName</strong> which means it was <strong>@_lastClosedModal</strong></p>
 }
 
 <button @onclick="ShowModal1" class="btn btn-primary">Show Modal 1</button>
@@ -26,8 +26,8 @@
         var parameters = new ModalParameters();
         parameters.Add("FormId", 11);
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        var modal = Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        modal.Closed += (result) => ModalClosed(modal, result);
     }
 
     void ShowModal2()
@@ -35,11 +35,11 @@
         var parameters = new ModalParameters();
         var options = new ModalOptions() { Style = "blazored-prompt-modal" };
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<YesNoPrompt>("Delete record?", options);
+        var modal = Modal.Show<YesNoPrompt>("Delete record?", options);
+        modal.Closed += (result) => ModalClosed(modal, result);
     }
 
-    void ModalClosed(ModalResult modalResult)
+    void ModalClosed(ModalReference modal, ModalResult modalResult)
     {
         Console.WriteLine("Modal has closed");
 
@@ -51,23 +51,9 @@
         {
             Console.WriteLine(modalResult.Data.ToString());
         }
-        _lastClosedModalType = modalResult.ModalType;
-        if (_lastClosedModalType == typeof(SignUpForm))
-        {
-            _lastClosedModal = "Modal 1";
-        }
-        else if(_lastClosedModalType == typeof(YesNoPrompt))
-        {
-            _lastClosedModal = "Modal 2";
-        }
-        else
-        {
-            _lastClosedModal = "Unknown";
-        }
+        _lastClosedModalType = modal.ComponentType;
+        _lastClosedModal = modal.Title;
         StateHasChanged();
-
-
-        Modal.OnClose -= ModalClosed;
     }
 
 }

--- a/samples/BlazorSample/Pages/ComponentInstance.razor
+++ b/samples/BlazorSample/Pages/ComponentInstance.razor
@@ -1,0 +1,49 @@
+﻿@page "/componentinstance"
+@inject IModalService Modal
+
+<h1>Accessing Component Instance</h1>
+
+<hr class="mb-5" />
+
+<p>
+    This example shows how to access instance of the component shown as the content of Blazored.Modal.
+    It can be usefull for setting component's properties or listeting to custom events
+</p>
+
+<p>
+    Following values will be set directly to the component instance properties:
+</p>
+<div class="form-group">
+    <label for="first-name">First Name</label>
+    <input @bind="DefaultFirstName" type="text" class="form-control" id="first-name" placeholder="Enter First Name" />
+</div>
+
+<div class="form-group">
+    <label for="last-name">Last Name</label>
+    <input @bind="DefaultLastName" type="text" class="form-control" id="last-name" placeholder="Enter Last Name" />
+</div>
+
+<button @onclick="ShowModal" class="btn btn-primary">Show SignUp Form</button>
+
+
+@code {
+
+    string DefaultFirstName { get; set; } = "John";
+    string DefaultLastName { get; set; } = "Smith";
+
+    void ShowModal()
+    {
+        var modal = Modal.Show<SignUpForm>("Sign Up Form");
+        modal.Showed += (instance) =>
+        {
+            var signUpForm = (SignUpForm)instance;
+            signUpForm.FirstName = DefaultFirstName;
+            signUpForm.LastName = DefaultLastName;
+            signUpForm.FormSubmitted += () =>
+            {
+                Console.WriteLine($"Form has been submitted");
+            };
+        };
+    }
+}
+

--- a/samples/BlazorSample/Pages/CustomStyle.razor
+++ b/samples/BlazorSample/Pages/CustomStyle.razor
@@ -27,8 +27,7 @@
 
         parameters.Add("FormId", 11);
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        Modal.Show<SignUpForm>("Sign Up Form", parameters).Closed += ModalClosed;
     }
 
     void ShowModalCustomStyle()
@@ -36,8 +35,7 @@
         var parameters = new ModalParameters();
         var options = new ModalOptions() { Style = "blazored-prompt-modal" };
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<YesNoPrompt>("Delete record?", options);
+        Modal.Show<YesNoPrompt>("Delete record?", options).Closed += ModalClosed;
     }
 
 
@@ -53,8 +51,6 @@
         {
             Console.WriteLine(modalResult.Data.ToString());
         }
-
-        Modal.OnClose -= ModalClosed;
     }
 
 }

--- a/samples/BlazorSample/Pages/Index.razor
+++ b/samples/BlazorSample/Pages/Index.razor
@@ -12,32 +12,51 @@
 
 <button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
 
+<button @onclick="ShowModalWithCallback" class="btn btn-secondary">Show Modal with callback</button>
+
+
 @code {
 
-    void ShowModal()
+    async void ShowModal()
     {
         var parameters = new ModalParameters();
         parameters.Add("FormId", 11);
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<SignUpForm>("Sign Up Form", parameters);
-    }
 
-    void ModalClosed(ModalResult modalResult)
-    {
+        var modal = Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        var result = await modal.Result;
         Console.WriteLine("Modal has closed");
 
-        if (modalResult.Cancelled)
+        if (result.Cancelled)
         {
             Console.WriteLine("Modal was Cancelled");
         }
         else
         {
-            Console.WriteLine(modalResult.Data.ToString());
+            Console.WriteLine(result.Data.ToString());
         }
-
-        Modal.OnClose -= ModalClosed;
     }
 
+    void ShowModalWithCallback()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 12);
+
+
+        var modal = Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        modal.Closed += result =>
+        {
+            Console.WriteLine("Modal has closed");
+
+            if (result.Cancelled)
+            {
+                Console.WriteLine("Modal was Cancelled");
+            }
+            else
+            {
+                Console.WriteLine(result.Data.ToString());
+            }
+        };
+    }
 }
 

--- a/samples/BlazorSample/Pages/SignUpForm.razor
+++ b/samples/BlazorSample/Pages/SignUpForm.razor
@@ -30,19 +30,24 @@ else
 
     [CascadingParameter] ModalParameters Parameters { get; set; }
 
+    public event Action FormSubmitted;
+
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+
     bool ShowForm { get; set; } = true;
-    string FirstName { get; set; }
-    string LastName { get; set; }
     int FormId { get; set; }
 
     protected override void OnInitialized()
     {
-        FormId = Parameters.Get<int>("FormId");
+        FormId = Parameters.TryGet<int>("FormId");
     }
+
 
     void SubmitForm()
     {
         ShowForm = false;
+        this.FormSubmitted?.Invoke();
     }
 
     void Done()

--- a/samples/BlazorSample/Shared/NavMenu.razor
+++ b/samples/BlazorSample/Shared/NavMenu.razor
@@ -23,6 +23,9 @@
             <NavLink class="nav-link" href="/position" Match="NavLinkMatch.All">
                 <span class="oi oi-grid-three-up" aria-hidden="true"></span> Position
             </NavLink>
+            <NavLink class="nav-link" href="/componentinstance" Match="NavLinkMatch.All">
+                <span class="oi oi-code" aria-hidden="true"></span> Component Instance
+            </NavLink>
             <NavLink class="nav-link" href="/closesource" Match="NavLinkMatch.All">
                 <span class="oi oi-code" aria-hidden="true"></span> Close Event ModalType
             </NavLink>

--- a/samples/ServerSideblazor/Pages/CloseSource.razor
+++ b/samples/ServerSideblazor/Pages/CloseSource.razor
@@ -26,8 +26,8 @@
         var parameters = new ModalParameters();
         parameters.Add("FormId", 11);
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        var modal = Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        modal.Closed += (result) => ProcessResult(modal, result);
     }
 
     void ShowModal2()
@@ -35,11 +35,11 @@
         var parameters = new ModalParameters();
         var options = new ModalOptions() { Style = "blazored-prompt-modal" };
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<YesNoPrompt>("Delete record?", options);
+        var modal = Modal.Show<YesNoPrompt>("Delete record?", options);
+        modal.Closed += (result) => ProcessResult(modal, result);
     }
 
-    void ModalClosed(ModalResult modalResult)
+    void ProcessResult(ModalReference modal, ModalResult modalResult)
     {
         Console.WriteLine("Modal has closed");
 
@@ -51,23 +51,9 @@
         {
             Console.WriteLine(modalResult.Data.ToString());
         }
-        _lastClosedModalType = modalResult.ModalType;
-        if (_lastClosedModalType == typeof(SignUpForm))
-        {
-            _lastClosedModal = "Modal 1";
-        }
-        else if(_lastClosedModalType == typeof(YesNoPrompt))
-        {
-            _lastClosedModal = "Modal 2";
-        }
-        else
-        {
-            _lastClosedModal = "Unknown";
-        }
+        _lastClosedModalType = modal.ComponentType;
+        _lastClosedModal = modal.Title;
         StateHasChanged();
-
-
-        Modal.OnClose -= ModalClosed;
     }
 
 }

--- a/samples/ServerSideblazor/Pages/ComponentInstance.razor
+++ b/samples/ServerSideblazor/Pages/ComponentInstance.razor
@@ -1,0 +1,46 @@
+﻿@page "/componentinstance"
+@inject IModalService Modal
+
+<h1>Accessing Component Instance</h1>
+
+<hr class="mb-5" />
+
+<p>
+    This example shows how to access instance of the component shown as the content of Blazored.Modal.
+    It can be usefull for setting component's properties or listeting to custom events
+</p>
+
+<div class="form-group">
+    <label for="first-name">First Name</label>
+    <input @bind="DefaultFirstName" type="text" class="form-control" id="first-name" placeholder="Enter First Name" />
+</div>
+
+<div class="form-group">
+    <label for="last-name">Last Name</label>
+    <input @bind="DefaultLastName" type="text" class="form-control" id="last-name" placeholder="Enter Last Name" />
+</div>
+
+<button @onclick="ShowModal" class="btn btn-primary">Show SignUp Form</button>
+
+
+@code {
+
+    string DefaultFirstName { get; set; } = "John";
+    string DefaultLastName { get; set; } = "Smith";
+
+    void ShowModal()
+    {
+        var modal = Modal.Show<SignUpForm>("Sign Up Form");
+        modal.Showed += (instance) =>
+        {
+            var signUpForm = (SignUpForm)instance;
+            signUpForm.FirstName = DefaultFirstName;
+            signUpForm.LastName = DefaultLastName;
+            signUpForm.FormSubmitted += () =>
+            {
+                Console.WriteLine($"Form has been submitted");
+            };
+        };
+    }
+}
+

--- a/samples/ServerSideblazor/Pages/CustomStyle.razor
+++ b/samples/ServerSideblazor/Pages/CustomStyle.razor
@@ -27,8 +27,7 @@
 
         parameters.Add("FormId", 11);
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        Modal.Show<SignUpForm>("Sign Up Form", parameters).Closed += ModalClosed;
     }
 
     void ShowModalCustomStyle()
@@ -36,8 +35,7 @@
         var parameters = new ModalParameters();
         var options = new ModalOptions() { Style = "blazored-prompt-modal" };
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<YesNoPrompt>("Delete record?", options);
+        Modal.Show<YesNoPrompt>("Delete record?", options).Closed += ModalClosed;
     }
 
 
@@ -53,8 +51,6 @@
         {
             Console.WriteLine(modalResult.Data.ToString());
         }
-
-        Modal.OnClose -= ModalClosed;
     }
 
 }

--- a/samples/ServerSideblazor/Pages/Index.razor
+++ b/samples/ServerSideblazor/Pages/Index.razor
@@ -12,32 +12,51 @@
 
 <button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
 
+<button @onclick="ShowModalWithCallback" class="btn btn-secondary">Show Modal with callback</button>
+
+
 @code {
 
-    void ShowModal()
+    async void ShowModal()
     {
         var parameters = new ModalParameters();
         parameters.Add("FormId", 11);
 
-        Modal.OnClose += ModalClosed;
-        Modal.Show<SignUpForm>("Sign Up Form", parameters);
-    }
 
-    void ModalClosed(ModalResult modalResult)
-    {
+        var modal = Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        var result = await modal.Result;
         Console.WriteLine("Modal has closed");
 
-        if (modalResult.Cancelled)
+        if (result.Cancelled)
         {
             Console.WriteLine("Modal was Cancelled");
         }
         else
         {
-            Console.WriteLine(modalResult.Data.ToString());
+            Console.WriteLine(result.Data.ToString());
         }
-
-        Modal.OnClose -= ModalClosed;
     }
 
+    void ShowModalWithCallback()
+    {
+        var parameters = new ModalParameters();
+        parameters.Add("FormId", 12);
+
+
+        var modal = Modal.Show<SignUpForm>("Sign Up Form", parameters);
+        modal.Closed += result =>
+        {
+            Console.WriteLine("Modal has closed");
+
+            if (result.Cancelled)
+            {
+                Console.WriteLine("Modal was Cancelled");
+            }
+            else
+            {
+                Console.WriteLine(result.Data.ToString());
+            }
+        };
+    }
 }
 

--- a/samples/ServerSideblazor/Pages/SignUpForm.razor
+++ b/samples/ServerSideblazor/Pages/SignUpForm.razor
@@ -31,20 +31,25 @@ else
     [CascadingParameter] ModalParameters Parameters { get; set; }
     [CascadingParameter] BlazoredModal BlazoredModal { get; set; }
 
+    public event Action FormSubmitted;
+
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+
     bool ShowForm { get; set; } = true;
-    string FirstName { get; set; }
-    string LastName { get; set; }
     int FormId { get; set; }
 
     protected override void OnInitialized()
     {
-        FormId = Parameters.Get<int>("FormId");
+        FormId = Parameters.TryGet<int>("FormId");
         BlazoredModal.SetTitle("Sheep");
     }
+
 
     void SubmitForm()
     {
         ShowForm = false;
+        this.FormSubmitted?.Invoke();
     }
 
     void Done()

--- a/samples/ServerSideblazor/Shared/NavMenu.razor
+++ b/samples/ServerSideblazor/Shared/NavMenu.razor
@@ -23,6 +23,9 @@
             <NavLink class="nav-link" href="/position" Match="NavLinkMatch.All">
                 <span class="oi oi-grid-three-up" aria-hidden="true"></span> Position
             </NavLink>
+            <NavLink class="nav-link" href="/componentinstance" Match="NavLinkMatch.All">
+                <span class="oi oi-code" aria-hidden="true"></span> Component Instance
+            </NavLink>
             <NavLink class="nav-link" href="/closesource" Match="NavLinkMatch.All">
                 <span class="oi oi-code" aria-hidden="true"></span> Close Event ModalType
             </NavLink>

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -43,13 +43,17 @@ namespace Blazored.Modal
             ((ModalService)ModalService).CloseModal += CloseModal;
         }
 
-        private async void ShowModal(string title, RenderFragment content, ModalParameters parameters, ModalOptions options)
+        private async void ShowModal(ModalReference modalReference)
         {
-            Title = title;
-            Content = content;
-            Parameters = parameters;
+            Title = modalReference.Title;
+            Content = new RenderFragment(builder => {
+                builder.OpenComponent(1, modalReference.ComponentType);
+                builder.AddComponentReferenceCapture(1, inst => { modalReference.SetComponentInstance((ComponentBase)inst); });
+                builder.CloseComponent(); 
+            });
+            Parameters = modalReference.Parameters;
 
-            SetModalOptions(options);
+            SetModalOptions(modalReference.Options);
 
             IsVisible = true;
             await InvokeAsync(StateHasChanged);

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -8,25 +8,26 @@ namespace Blazored.Modal.Services
         /// <summary>
         /// Invoked when the modal component closes.
         /// </summary>
+        [Obsolete("Use ModalReference.Closed")]
         event Action<ModalResult> OnClose;
 
         /// <summary>
         /// Shows the modal with the component type.
         /// </summary>
-        void Show<T>() where T : ComponentBase;
+        ModalReference Show<T>() where T : ComponentBase;
 
         /// <summary>
         /// Shows the modal using the specified title and component type.
         /// </summary>
         /// <param name="title">Modal title.</param>
-        void Show<T>(string title) where T : ComponentBase;
+        ModalReference Show<T>(string title) where T : ComponentBase;
 
         /// <summary>
         /// Shows the modal using the specified title and component type.
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="options">Options to configure the modal.</param>
-        void Show<T>(string title, ModalOptions options) where T : ComponentBase;
+        ModalReference Show<T>(string title, ModalOptions options) where T : ComponentBase;
 
         /// <summary>
         /// Shows the modal using the specified <paramref name="title"/> and <paramref name="componentType"/>, 
@@ -34,7 +35,7 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        void Show<T>(string title, ModalParameters parameters) where T : ComponentBase;
+        ModalReference Show<T>(string title, ModalParameters parameters) where T : ComponentBase;
 
         /// <summary>
         /// Shows the modal for the specified component type using the specified <paramref name="title"/>
@@ -44,20 +45,20 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        void Show<T>(string title, ModalParameters parameters = null, ModalOptions options = null) where T : ComponentBase;
+        ModalReference Show<T>(string title, ModalParameters parameters = null, ModalOptions options = null) where T : ComponentBase;
 
         /// <summary>
         /// Shows the modal with the specific component type.
         /// </summary>
         /// <param name="contentComponent">Type of component to display.</param>
-        void Show(Type contentComponent);
+        ModalReference Show(Type contentComponent);
 
         /// <summary>
         /// Shows the modal with the component type using the specified title.
         /// </summary>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="title">Modal title.</param>
-        void Show(Type contentComponent, string title);
+        ModalReference Show(Type contentComponent, string title);
 
         /// <summary>
         /// Shows the modal with the component type using the specified title.
@@ -65,7 +66,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="options">Options to configure the modal.</param>
-        void Show(Type contentComponent, string title, ModalOptions options);
+        ModalReference Show(Type contentComponent, string title, ModalOptions options);
 
         /// <summary>
         /// Shows the modal with the component type using the specified <paramref name="title"/>, 
@@ -74,7 +75,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        void Show(Type contentComponent, string title, ModalParameters parameters);
+        ModalReference Show(Type contentComponent, string title, ModalParameters parameters);
 
         /// <summary>
         /// Shows the modal with the component type using the specified <paramref name="title"/>, 
@@ -83,7 +84,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        void Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options);
+        ModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options);
 
         /// <summary>
         /// Cancels the modal and invokes the <see cref="OnClose"/> event.

--- a/src/Blazored.Modal/Services/ModalReference.cs
+++ b/src/Blazored.Modal/Services/ModalReference.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Components;
+using System;
+using System.Threading.Tasks;
+
+namespace Blazored.Modal.Services
+{
+    /// <summary>
+    ///  A reference to the currently opened (active) modal.
+    /// </summary>
+    public class ModalReference
+    {
+        private TaskCompletionSource<ModalResult> _resultCompletion;
+
+        public event Action<ComponentBase> Showed;
+        public event Action<ModalResult> Closed;
+
+        public ModalReference(
+            Type componentType,
+            string title,
+            ModalParameters parameters,
+            ModalOptions options)
+        {
+            ComponentType = componentType;
+            Title = title;
+            Parameters = parameters;
+            Options = options;
+
+            _resultCompletion = new TaskCompletionSource<ModalResult>();
+            Closed += (result) => _resultCompletion.SetResult(result);
+        }
+
+        public Type ComponentType { get; }
+
+        /// <summary>
+        /// Null by default. It will be set after <see cref="Showed"/> event is invoked.
+        /// </summary>
+        public ComponentBase ComponentInstance { get; protected set; }
+        public string Title { get; }
+        public ModalParameters Parameters { get; }
+        public ModalOptions Options { get; }
+
+        public Task<ModalResult> Result => _resultCompletion.Task;
+        
+
+        internal virtual void SetComponentInstance(ComponentBase instance)
+        {
+            this.ComponentInstance = instance;
+            Showed?.Invoke(instance);
+        }
+
+        internal virtual void Close(ModalResult result)
+        {
+            this.Closed.Invoke(result);
+        }
+    }
+}

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -18,25 +18,25 @@ namespace Blazored.Modal.Services
         /// <summary>
         /// Internal event used to trigger the modal component to show.
         /// </summary>
-        internal event Action<string, RenderFragment, ModalParameters, ModalOptions> OnShow;
+        internal event Action<ModalReference> OnShow;
 
         private Type _modalType;
 
         /// <summary>
         /// Shows the modal with the component type.
         /// </summary>
-        public void Show<T>() where T : ComponentBase
+        public ModalReference Show<T>() where T : ComponentBase
         {
-            Show<T>(string.Empty, new ModalParameters(), new ModalOptions());
+            return Show<T>(string.Empty, new ModalParameters(), new ModalOptions());
         }
 
         /// <summary>
         /// Shows the modal with the component type using the specified title.
         /// </summary>
         /// <param name="title">Modal title.</param>
-        public void Show<T>(string title) where T : ComponentBase
+        public ModalReference Show<T>(string title) where T : ComponentBase
         {
-            Show<T>(title, new ModalParameters(), new ModalOptions());
+            return Show<T>(title, new ModalParameters(), new ModalOptions());
         }
 
         /// <summary>
@@ -44,9 +44,9 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public void Show<T>(string title, ModalOptions options) where T : ComponentBase
+        public ModalReference Show<T>(string title, ModalOptions options) where T : ComponentBase
         {
-            Show<T>(title, new ModalParameters(), options);
+            return Show<T>(title, new ModalParameters(), options);
         }
 
         /// <summary>
@@ -55,9 +55,9 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        public void Show<T>(string title, ModalParameters parameters) where T : ComponentBase
+        public ModalReference Show<T>(string title, ModalParameters parameters) where T : ComponentBase
         {
-            Show<T>(title, parameters, new ModalOptions());
+            return Show<T>(title, parameters, new ModalOptions());
         }
 
         /// <summary>
@@ -67,18 +67,18 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public void Show<T>(string title, ModalParameters parameters, ModalOptions options) where T : ComponentBase
+        public ModalReference Show<T>(string title, ModalParameters parameters, ModalOptions options) where T : ComponentBase
         {
-            Show(typeof(T), title, parameters, options);
+            return Show(typeof(T), title, parameters, options);
         }
 
         /// <summary>
         /// Shows the modal with the specific component type.
         /// </summary>
         /// <param name="contentComponent">Type of component to display.</param>
-        public void Show(Type contentComponent)
+        public ModalReference Show(Type contentComponent)
         {
-            Show(contentComponent, string.Empty, new ModalParameters(), new ModalOptions());
+            return Show(contentComponent, string.Empty, new ModalParameters(), new ModalOptions());
         }
 
         /// <summary>
@@ -86,9 +86,9 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="title">Modal title.</param>
-        public void Show(Type contentComponent, string title)
+        public ModalReference Show(Type contentComponent, string title)
         {
-            Show(contentComponent, title, new ModalParameters(), new ModalOptions());
+            return Show(contentComponent, title, new ModalParameters(), new ModalOptions());
         }
 
         /// <summary>
@@ -97,9 +97,9 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public void Show(Type contentComponent, string title, ModalOptions options)
+        public ModalReference Show(Type contentComponent, string title, ModalOptions options)
         {
-            Show(contentComponent, title, new ModalParameters(), options);
+            return Show(contentComponent, title, new ModalParameters(), options);
         }
 
         /// <summary>
@@ -109,9 +109,9 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        public void Show(Type contentComponent, string title, ModalParameters parameters)
+        public ModalReference Show(Type contentComponent, string title, ModalParameters parameters)
         {
-            Show(contentComponent, title, parameters, new ModalOptions());
+            return Show(contentComponent, title, parameters, new ModalOptions());
         }
 
         /// <summary>
@@ -121,17 +121,21 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public void Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options)
+        public ModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options)
         {
             if (!typeof(ComponentBase).IsAssignableFrom(contentComponent))
             {
                 throw new ArgumentException($"{contentComponent.FullName} must be a Blazor Component");
             }
 
-            var content = new RenderFragment(x => { x.OpenComponent(1, contentComponent); x.CloseComponent(); });
+
             _modalType = contentComponent;
 
-            OnShow?.Invoke(title, content, parameters, options);
+            var modalReference = new ModalReference(contentComponent, title, parameters, options);
+
+            OnShow?.Invoke(modalReference);
+
+            return modalReference;
         }
 
         /// <summary>


### PR DESCRIPTION
Implements #103

- Allows accessing content component instance
- Adds Closed event specific to modal instance
- Allows awaiting result
- Makes IModalService.OnClose obsolete


Inspired by Angular-Material Modal service