### PR TITLE
Bugfix/modal cancel

### DIFF
--- a/samples/BlazorServer/Pages/ReturnDataFromModal.razor
+++ b/samples/BlazorServer/Pages/ReturnDataFromModal.razor
@@ -43,7 +43,7 @@
         var result = await messageForm.Result;
 
         if (!result.Cancelled)
-            _message = result.Data.ToString();
+            _message = result.Data?.ToString() ?? string.Empty;
     }
 
 }

--- a/samples/BlazorServer/Shared/Confirm.razor
+++ b/samples/BlazorServer/Shared/Confirm.razor
@@ -10,6 +10,6 @@
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
     void Close() => BlazoredModal.Close(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Close(ModalResult.Cancel());
+    void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorServer/Shared/DisplayMessage.razor
+++ b/samples/BlazorServer/Shared/DisplayMessage.razor
@@ -13,6 +13,6 @@
     [Parameter] public string Message { get; set; }
 
     void SubmitForm() => BlazoredModal.Close();
-    void Cancel() => BlazoredModal.Close();
+    void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorServer/Shared/MessageForm.razor
+++ b/samples/BlazorServer/Shared/MessageForm.razor
@@ -18,6 +18,6 @@
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
     
     void SubmitForm() => BlazoredModal.Close(ModalResult.Ok(Message));
-    void Cancel() => BlazoredModal.Close();
+    void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorWebAssembly/Pages/ReturnDataFromModal.razor
+++ b/samples/BlazorWebAssembly/Pages/ReturnDataFromModal.razor
@@ -43,7 +43,7 @@
         var result = await messageForm.Result;
 
         if (!result.Cancelled)
-            _message = result.Data.ToString();
+            _message = result.Data?.ToString() ?? string.Empty;
     }
 
 }

--- a/samples/BlazorWebAssembly/Shared/Confirm.razor
+++ b/samples/BlazorWebAssembly/Shared/Confirm.razor
@@ -10,6 +10,6 @@
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
     void Close() => BlazoredModal.Close(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Close(ModalResult.Cancel());
+    void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
+++ b/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
@@ -13,6 +13,6 @@
     [Parameter] public string Message { get; set; }
 
     void SubmitForm() => BlazoredModal.Close();
-    void Cancel() => BlazoredModal.Close();
+    void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorWebAssembly/Shared/MessageForm.razor
+++ b/samples/BlazorWebAssembly/Shared/MessageForm.razor
@@ -18,6 +18,6 @@
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
     
     void SubmitForm() => BlazoredModal.Close(ModalResult.Ok(Message));
-    void Cancel() => BlazoredModal.Close();
+    void Cancel() => BlazoredModal.Cancel();
 
 }


### PR DESCRIPTION
This small PR should fix #118. I also fixed a situation where the modal was not cancelled but the result was still Null.

Unrelated: Now that there are Github Actions, I head to sign out and sign in from Github Desktop to be able to use it. This issue is not obvious from the error message and nothing @chrissainty can do about, but maybe good to either document somewhere or keep in mind for future contributers. Propably with time it will not be necessary anymore. Anyway, see [this](https://github.community/t5/GitHub-Actions/Refusing-to-allow-an-integration-to-create-or-update/td-p/32472) for more info.