### PR TITLE
Add generic Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,36 @@ Below is a component which being displayed inside a Blazored Modal instance. Whe
 
 }
 ```
+### Generic Modal
+
+possibility to open a generic modal, passing as parameter, the title, the message, the type (if it is an error show the error icon next to the title and so on ...),
+
+the button you want to see, and the possible button translations (the latter are optional parameters)
+
+```razor
+@page "/"
+@inject IModalService Modal
+
+<button @onclick="ShowModal" class="btn btn-primary">View Generic Modal</button>
+
+@code {
+    async Task ShowModal()
+    {
+        var messageResult = Modal.ShowGeneric("Welcome to Blazored Generic Modal", "Generic Message Custom", ModalButton.YesNo, ModalType.Question, captionYesButton: "Si");
+        var result = await messageResult.Result;
+        Console.WriteLine(result);
+    }
+}
+```
+
+Setting the icon class also requires  for example:
+
+```html
+
+<BlazoredModal                              
+               QuestionIconClass="fa fa-question-circle"
+               WarningIconClass="fa fa-exclamation-triangle"
+               InfoIconClass="fa fa-info-circle"
+               SuccessIconClass="fa fa-thumbs-up"
+               ErrorIconClass="fa fa-bug"  />
+```

--- a/samples/BlazorWebAssembly/Pages/GenericModal.razor
+++ b/samples/BlazorWebAssembly/Pages/GenericModal.razor
@@ -1,0 +1,34 @@
+﻿@page "/genericmodal"
+@inject IModalService Modal
+
+<h1>Blazored Generic Modal Sample</h1>
+
+<hr class="mb-5" />
+
+<p>
+    This is an example of using Blazored Generic Modal in its most simplistic form.
+</p>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("Modal.Show<Confirm>(\"Welcome to Blazored Modal\", \"Message Body\",ModalButton,ModalType,captionYesButton:optional,captionNoButton:optional,captionOkButton:optional,captionCancelButton:optional);")
+            </code>
+        </p>
+    </div>
+</div>
+
+<button @onclick="ShowModal" class="btn btn-primary">Show Generic Modal</button>
+
+@code {
+
+    async Task ShowModal()
+    {
+        var messageResult = Modal.ShowGeneric("Welcome to Blazored Generic Modal", "Generic Message Custom", ModalButton.YesNo, ModalType.Question, captionYesButton: "Si");
+        var result = await messageResult.Result;
+        Console.WriteLine(result);
+    }
+
+}
+

--- a/samples/BlazorWebAssembly/Shared/MainLayout.razor
+++ b/samples/BlazorWebAssembly/Shared/MainLayout.razor
@@ -1,6 +1,11 @@
 ﻿@inherits LayoutComponentBase
 
-<BlazoredModal />
+<BlazoredModal                              
+               QuestionIconClass="fa fa-question-circle"
+               WarningIconClass="fa fa-exclamation-triangle"
+               InfoIconClass="fa fa-info-circle"
+               SuccessIconClass="fa fa-thumbs-up"
+               ErrorIconClass="fa fa-bug"  />
 
 <div class="sidebar">
     <NavMenu />

--- a/samples/BlazorWebAssembly/Shared/NavMenu.razor
+++ b/samples/BlazorWebAssembly/Shared/NavMenu.razor
@@ -28,9 +28,12 @@
             </NavLink>
             <NavLink class="nav-link" href="/passingdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data
-            </NavLink>            
+            </NavLink>
             <NavLink class="nav-link" href="/returningdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Returning Data
+            </NavLink>
+            <NavLink class="nav-link" href="/genericmodal" Match="NavLinkMatch.All">
+                <span class="oi oi-loop-square" aria-hidden="true"></span> Generic Modal
             </NavLink>
         </li>
     </ul>

--- a/samples/BlazorWebAssembly/wwwroot/index.html
+++ b/samples/BlazorWebAssembly/wwwroot/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width">
     <title>Blazored Modal (Wasm)</title>
     <base href="/" />
+    <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="_content/Blazored.Modal/blazored-modal.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />

--- a/src/Blazored.Modal/Blazored.Modal.csproj
+++ b/src/Blazored.Modal/Blazored.Modal.csproj
@@ -16,7 +16,7 @@
     <PackageTags>Blazored Blazor Razor Components Modal Dialogue</PackageTags>
     <Description>A JavaScript free modal library for Blazor and Razor Components applications.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -18,6 +18,13 @@ namespace Blazored.Modal
         [Parameter] public ModalPosition? Position { get; set; }
         [Parameter] public string Class { get; set; }
 
+        [Parameter] public string SuccessIconClass { get; set; }
+        [Parameter] public string InfoIconClass { get; set; }
+        [Parameter] public string QuestionIconClass { get; set; }
+        [Parameter] public string WarningIconClass { get; set; }
+        [Parameter] public string ErrorIconClass { get; set; }
+
+
         private readonly Collection<ModalReference> Modals = new Collection<ModalReference>();
         private readonly ModalOptions GlobalModalOptions = new ModalOptions();
 

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -7,7 +7,27 @@
             @if (!HideHeader)
             {
                 <div class="blazored-modal-header">
-                    <h3 class="blazored-modal-title">@Title</h3>
+                    <h3 class="blazored-modal-title">
+                        @switch (ModalType)
+                        {
+                            case ModalType.Info:
+                                <span class="@Parent.InfoIconClass"></span>
+                                break;
+                            case ModalType.Warning:
+                                <span class="@Parent.WarningIconClass"></span>
+                                break;
+                            case ModalType.Error:
+                                <span class="@Parent.ErrorIconClass"></span>
+                                break;
+                            case ModalType.Success:
+                                <span class="@Parent.SuccessIconClass"></span>
+                                break;
+                            case ModalType.Question:
+                                <span class="@Parent.QuestionIconClass"></span>
+                                break;
+                        }
+                        @Title
+                    </h3>
                     @if (!HideCloseButton)
                     {
                         <button type="button" class="blazored-modal-close" @onclick="(() => Parent.CancelInstance(Id))">
@@ -28,6 +48,16 @@
 @code {
     [CascadingParameter] private BlazoredModal Parent { get; set; }
     [CascadingParameter] private ModalOptions GlobalModalOptions { get; set; }
+
+
+    [Parameter] public string Message { get; set; }
+    [Parameter] public string CaptionYesButton { get; set; }
+    [Parameter] public string CaptionNoButton { get; set; }
+    [Parameter] public string CaptionCancelButton { get; set; }
+    [Parameter] public string CaptionOkButton { get; set; }
+    [Parameter] public ModalType ModalType { get; set; }
+    [Parameter] public ModalButton ModalButton { get; set; }
+
 
     [Parameter] public ModalOptions Options { get; set; }
     [Parameter] public string Title { get; set; }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -6,35 +6,35 @@
         <div class="@Class">
             @if (!HideHeader)
             {
-                <div class="blazored-modal-header">
-                    <h3 class="blazored-modal-title">
-                        @switch (ModalType)
-                        {
-                            case ModalType.Info:
-                                <span class="@Parent.InfoIconClass"></span>
-                                break;
-                            case ModalType.Warning:
-                                <span class="@Parent.WarningIconClass"></span>
-                                break;
-                            case ModalType.Error:
-                                <span class="@Parent.ErrorIconClass"></span>
-                                break;
-                            case ModalType.Success:
-                                <span class="@Parent.SuccessIconClass"></span>
-                                break;
-                            case ModalType.Question:
-                                <span class="@Parent.QuestionIconClass"></span>
-                                break;
-                        }
-                        @Title
-                    </h3>
-                    @if (!HideCloseButton)
+            <div class="blazored-modal-header">
+                <h3 class="mr-2">
+                @switch (ModalType)
                     {
-                        <button type="button" class="blazored-modal-close" @onclick="(() => Parent.CancelInstance(Id))">
-                            <span>&times;</span>
-                        </button>
-                    }
-                </div>
+                    case ModalType.Info:
+                        <span class="@Parent.InfoIconClass"></span>
+                        break;
+                    case ModalType.Warning:
+                        <span class="@Parent.WarningIconClass"></span>
+                        break;
+                    case ModalType.Error:
+                        <span class="@Parent.ErrorIconClass"></span>
+                        break;
+                    case ModalType.Success:
+                        <span class="@Parent.SuccessIconClass"></span>
+                        break;
+                    case ModalType.Question:
+                        <span class="@Parent.QuestionIconClass"></span>
+                        break;
+                }
+                </h3>
+                <h3 class="blazored-modal-title">@Title</h3>
+                @if (!HideCloseButton)
+                {
+                    <button type="button" class="blazored-modal-close" @onclick="(() => Parent.CancelInstance(Id))">
+                        <span>&times;</span>
+                    </button>
+                }
+            </div>
             }
             <div class="blazored-modal-content">
                 <CascadingValue Value="this">

--- a/src/Blazored.Modal/ModalButton.cs
+++ b/src/Blazored.Modal/ModalButton.cs
@@ -1,0 +1,10 @@
+﻿namespace Blazored.Modal
+{
+    public enum ModalButton
+    {
+        Null,
+        OK,
+        Cancel,
+        YesNo
+    }
+}

--- a/src/Blazored.Modal/ModalGeneric.razor
+++ b/src/Blazored.Modal/ModalGeneric.razor
@@ -1,0 +1,20 @@
+﻿<div>
+    <p>
+        @BlazoredModal.Message
+    </p>
+    @switch (BlazoredModal.ModalButton)
+    {
+        case ModalButton.YesNo:
+            <button class="btn btn-primary float-right ml-2" @onclick="() => Close(true)">@(!string.IsNullOrEmpty(BlazoredModal.CaptionYesButton) ? BlazoredModal.CaptionYesButton : "Yes")</button>
+            <button class="btn btn-secondary float-right" @onclick="() => Close(false)">@(!string.IsNullOrEmpty(BlazoredModal.CaptionNoButton) ? BlazoredModal.CaptionNoButton : "No")</button>
+            break;
+        case ModalButton.Cancel:
+            <button class="btn btn-secondary float-right" @onclick="() => Cancel()">@(!string.IsNullOrEmpty(BlazoredModal.CaptionCancelButton) ? BlazoredModal.CaptionCancelButton : "Cancel")</button>
+            break;
+        default:
+            <button class="btn btn-primary float-right" @onclick="() => Close(true)">@(!string.IsNullOrEmpty(BlazoredModal.CaptionOkButton) ? BlazoredModal.CaptionOkButton : "Ok")</button>
+            break;
+    }
+
+</div>
+

--- a/src/Blazored.Modal/ModalGeneric.razor.cs
+++ b/src/Blazored.Modal/ModalGeneric.razor.cs
@@ -1,0 +1,26 @@
+﻿using Blazored.Modal.Services;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazored.Modal
+{
+    public partial class ModalGeneric
+    {
+        [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
+
+
+
+
+        private void Close(bool result)
+        {
+            BlazoredModal.Close(ModalResult.Ok(result));
+        }
+        private void Cancel()
+        {
+            BlazoredModal.Cancel();
+        }
+
+    }
+}

--- a/src/Blazored.Modal/ModalType.cs
+++ b/src/Blazored.Modal/ModalType.cs
@@ -1,0 +1,12 @@
+﻿namespace Blazored.Modal
+{
+    public enum ModalType
+    {
+        Null,
+        Warning,
+        Error,
+        Question,
+        Info,
+        Success 
+    }
+}

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -5,6 +5,15 @@ namespace Blazored.Modal.Services
 {
     public interface IModalService
     {
+
+        /// <summary>
+        /// Shows a modal generic containing a <paramref name="component"/>.
+        /// </summary>
+        /// <param name="component">Type of component to display.</param>
+        ModalReference ShowGeneric(string title, string message, ModalButton modalButton, ModalType modalType, string captionYesButton = null, string captionNoButton = null, string captionOkButton = null, string captionCancelButton = null);
+
+
+
         /// <summary>
         /// Shows a modal containing the specified <typeparamref name="TComponent"/>.
         /// </summary>
@@ -75,6 +84,6 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        ModalReference Show(Type component, string title, ModalParameters parameters, ModalOptions options);
+        ModalReference Show(Type component, string title, ModalParameters parameters, ModalOptions options, string message = null, ModalButton modalButton = 0, ModalType modalType = 0, string captionYesButton = null, string captionNoButton = null, string captionOkButton = null, string captionCancelButton = null);
     }
 }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -7,6 +7,21 @@ namespace Blazored.Modal.Services
     {
         internal event Action<ModalReference> OnModalInstanceAdded;
 
+
+
+        /// <summary>
+        /// Shows the modal generic with the specific component type.
+        /// </summary>
+        /// <param name="contentComponent">Type of component to display.</param>
+        public ModalReference ShowGeneric(string title, string message, ModalButton modalButton, ModalType modalType, string captionYesButton = null,
+            string captionNoButton = null, string captionOkButton = null, string captionCancelButton = null)
+        {
+            return Show(typeof(ModalGeneric), title, new ModalParameters(), new ModalOptions(), message: message, modalButton: modalButton,
+                modalType: modalType, captionYesButton: captionYesButton, captionNoButton: captionNoButton, captionOkButton: captionOkButton, captionCancelButton: captionCancelButton);
+        }
+
+
+
         /// <summary>
         /// Shows the modal with the component type.
         /// </summary>
@@ -106,7 +121,9 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public ModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options)
+        public ModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options,
+            string message = null, ModalButton modalButton = 0, ModalType modalType = 0, string captionYesButton = null,
+            string captionNoButton = null, string captionOkButton = null, string captionCancelButton = null)
         {
             if (!typeof(ComponentBase).IsAssignableFrom(contentComponent))
             {
@@ -131,6 +148,13 @@ namespace Blazored.Modal.Services
                 builder.AddAttribute(2, "Title", title);
                 builder.AddAttribute(3, "Content", modalContent);
                 builder.AddAttribute(4, "Id", modalInstanceId);
+                builder.AddAttribute(5, "Message", message);
+                builder.AddAttribute(6, "ModalButton", modalButton);
+                builder.AddAttribute(7, "ModalType", modalType);
+                builder.AddAttribute(8, "CaptionYesButton", captionYesButton);
+                builder.AddAttribute(9, "CaptionNoButton", captionNoButton);
+                builder.AddAttribute(10, "CaptionOkButton", captionOkButton);
+                builder.AddAttribute(11, "CaptionCancelButton", captionCancelButton);
                 builder.CloseComponent();
             });
             var modalReference = new ModalReference(modalInstanceId, modalInstance);


### PR DESCRIPTION
hi, I created a PR, where I created a generic modal, in which I pass the title, the message, the type of icon that must be seen next to the title, the type of buttons that will appear on the popup footer and any translations of the captions buttons. I am new in blazor, obviously it has to be revised, I wanted to know what you thought of it and in case if you could then release it.

with this solution 80% of the modal cases could be resolved instead of creating n razor components for each modal