### PR TITLE
Closing modal using ModalReference

### DIFF
--- a/docs/src/customisation-options/toc.yml
+++ b/docs/src/customisation-options/toc.yml
@@ -14,6 +14,8 @@
       href: ../usage/returning-data-from-modals.md
     - name: Multiple Modals
       href: ../usage/multiple-modals.md
+    - name: Long-running Tasks
+      href: ../usage/long-running-task.md
 - name: Customisation Options
   items:
     - name: Position

--- a/docs/src/getting-started/toc.yml
+++ b/docs/src/getting-started/toc.yml
@@ -14,6 +14,8 @@
       href: ../usage/returning-data-from-modals.md
     - name: Multiple Modals
       href: ../usage/multiple-modals.md
+    - name: Long-running Tasks
+      href: ../usage/long-running-task.md
 - name: Customisation Options
   items:
     - name: Position

--- a/docs/src/usage/long-running-task.md
+++ b/docs/src/usage/long-running-task.md
@@ -1,0 +1,29 @@
+# Long running task
+How to open a modal, execute a long-running task and close the modal after it.
+
+---
+
+We can open a modal and using its `ModalReference` we can also close it from outside of the actual Modal itself.
+
+```html
+<button @onclick="ShowModal">Execute long-running task</button>
+
+@code {
+
+    string _message;
+
+    async Task ShowModal()
+    {
+        var loadingModal = Modal.Show<Loading>();
+		
+        await Task.Delay(5000); //Do your long running task, here we just wait 5 seconds
+		
+        loadingModal.Close();
+		
+        var result = await loadingModal.Result;
+        //Do something with the result. 
+        //In this case we won't as we just showed a loading dialog
+    }
+
+}
+```

--- a/docs/src/usage/toc.yml
+++ b/docs/src/usage/toc.yml
@@ -14,6 +14,8 @@
       href: returning-data-from-modals.md
     - name: Multiple Modals
       href: multiple-modals.md
+    - name: Long-running Tasks
+      href: long-running-task.md
 - name: Customisation Options
   items:
     - name: Position

--- a/samples/BlazorServer/Pages/LongRunningTask.razor
+++ b/samples/BlazorServer/Pages/LongRunningTask.razor
@@ -1,0 +1,96 @@
+﻿@page "/longrunningtask"
+@inject IModalService Modal
+
+<h1>Closing Modal after long-running task</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A long-running task can be executed and a modal can be closed programatically after it.
+</p>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("var loading = Modal.Show<Loading>();")<br />
+                @("await Task.Delay(5000);")<br />
+                <br />
+                @("loading.Close();")<br />
+            </code>
+        </p>
+    </div>
+</div>
+
+<p>Result: @_result;</p>
+
+<button @onclick="ShowModal" class="btn btn-primary">Long-running task default ModalResult</button>
+<button @onclick="ShowOkResultModal" class="btn btn-primary">Long-running task OK result</button>
+<button @onclick="ShowCancelModal" class="btn btn-primary">Long-running task with cancelled result</button>
+
+
+@code {
+
+    string _result;
+
+    async Task ShowModal()
+    {
+        var options = new ModalOptions
+        {
+            HideCloseButton = false,
+            DisableBackgroundCancel = true,
+            HideHeader = true
+        };
+        var loading = Modal.Show<Loading>(string.Empty, options);
+
+        await Task.Delay(5000);
+
+        loading.Close();
+        var result = await loading.Result;
+        if (result.Data == null && result.DataType == typeof(object))
+            _result = "Modal returned with default ModalResult";
+
+        StateHasChanged();
+    }
+
+    async Task ShowOkResultModal()
+    {
+        var options = new ModalOptions
+        {
+            HideCloseButton = false,
+            DisableBackgroundCancel = true,
+            HideHeader = true
+        };
+        var loading = Modal.Show<Loading>(string.Empty, options);
+
+        await Task.Delay(5000);
+
+        loading.Close(ModalResult.Ok("Closed with OK result"));
+        var result = await loading.Result;
+        if (result.DataType == typeof(string))
+            _result = result.Data.ToString();
+
+        StateHasChanged();
+    }
+
+    async Task ShowCancelModal()
+    {
+        var options = new ModalOptions
+        {
+            HideCloseButton = false,
+            DisableBackgroundCancel = true,
+            HideHeader = true
+        };
+        var loading = Modal.Show<Loading>(string.Empty, options);
+
+        await Task.Delay(5000);
+
+        loading.Close(ModalResult.Cancel());
+        var result = await loading.Result;
+        if (result.Cancelled)
+            _result = "Closed with Cancelled result";
+
+        StateHasChanged();
+    }
+
+}

--- a/samples/BlazorServer/Shared/Loading.razor
+++ b/samples/BlazorServer/Shared/Loading.razor
@@ -1,0 +1,115 @@
+﻿<style>
+    .lds-roller {
+        display: inline-block;
+        position: relative;
+        width: 80px;
+        height: 80px;
+    }
+
+        .lds-roller div {
+            animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+            transform-origin: 40px 40px;
+        }
+
+            .lds-roller div:after {
+                content: " ";
+                display: block;
+                position: absolute;
+                width: 7px;
+                height: 7px;
+                border-radius: 50%;
+                background: #000000;
+                margin: -4px 0 0 -4px;
+            }
+
+            .lds-roller div:nth-child(1) {
+                animation-delay: -0.036s;
+            }
+
+                .lds-roller div:nth-child(1):after {
+                    top: 63px;
+                    left: 63px;
+                }
+
+            .lds-roller div:nth-child(2) {
+                animation-delay: -0.072s;
+            }
+
+                .lds-roller div:nth-child(2):after {
+                    top: 68px;
+                    left: 56px;
+                }
+
+            .lds-roller div:nth-child(3) {
+                animation-delay: -0.108s;
+            }
+
+                .lds-roller div:nth-child(3):after {
+                    top: 71px;
+                    left: 48px;
+                }
+
+            .lds-roller div:nth-child(4) {
+                animation-delay: -0.144s;
+            }
+
+                .lds-roller div:nth-child(4):after {
+                    top: 72px;
+                    left: 40px;
+                }
+
+            .lds-roller div:nth-child(5) {
+                animation-delay: -0.18s;
+            }
+
+                .lds-roller div:nth-child(5):after {
+                    top: 71px;
+                    left: 32px;
+                }
+
+            .lds-roller div:nth-child(6) {
+                animation-delay: -0.216s;
+            }
+
+                .lds-roller div:nth-child(6):after {
+                    top: 68px;
+                    left: 24px;
+                }
+
+            .lds-roller div:nth-child(7) {
+                animation-delay: -0.252s;
+            }
+
+                .lds-roller div:nth-child(7):after {
+                    top: 63px;
+                    left: 17px;
+                }
+
+            .lds-roller div:nth-child(8) {
+                animation-delay: -0.288s;
+            }
+
+                .lds-roller div:nth-child(8):after {
+                    top: 56px;
+                    left: 12px;
+                }
+
+    @@keyframes lds-roller {
+        0% {
+            transform: rotate(0deg);
+        }
+
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+</style>
+
+<div style="width: 500px; height: 500px; line-height: 525px; text-align: center;">
+    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+</div>
+
+@code {
+
+    [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
+}

--- a/samples/BlazorServer/Shared/NavMenu.razor
+++ b/samples/BlazorServer/Shared/NavMenu.razor
@@ -28,9 +28,12 @@
             </NavLink>
             <NavLink class="nav-link" href="/passingdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data
-            </NavLink>            
+            </NavLink>
             <NavLink class="nav-link" href="/returningdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Returning Data
+            </NavLink>
+            <NavLink class="nav-link" href="/longrunningtask" Match="NavLinkMatch.All">
+                <span class="oi oi-loop-circular" aria-hidden="true"></span> Long running task
             </NavLink>
         </li>
     </ul>

--- a/samples/BlazorWebAssembly/Pages/LongRunningTask.razor
+++ b/samples/BlazorWebAssembly/Pages/LongRunningTask.razor
@@ -1,0 +1,96 @@
+﻿@page "/longrunningtask"
+@inject IModalService Modal
+
+<h1>Closing Modal after long-running task</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A long-running task can be executed and a modal can be closed programatically after it.
+</p>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("var loading = Modal.Show<Loading>();")<br />
+                @("await Task.Delay(5000);")<br />
+                <br />
+                @("loading.Close();")<br />
+            </code>
+        </p>
+    </div>
+</div>
+
+<p>Result: @_result;</p>
+
+<button @onclick="ShowModal" class="btn btn-primary">Long-running task default ModalResult</button>
+<button @onclick="ShowOkResultModal" class="btn btn-primary">Long-running task OK result</button>
+<button @onclick="ShowCancelModal" class="btn btn-primary">Long-running task with cancelled result</button>
+
+
+@code {
+
+    string _result;
+
+    async Task ShowModal()
+    {
+        var options = new ModalOptions
+        {
+            HideCloseButton = false,
+            DisableBackgroundCancel = true,
+            HideHeader = true
+        };
+        var loading = Modal.Show<Loading>(string.Empty, options);
+
+        await Task.Delay(5000);
+
+        loading.Close();
+        var result = await loading.Result;
+        if (result.Data == null && result.DataType == typeof(object))
+            _result = "Modal returned with default ModalResult";
+
+        StateHasChanged();
+    }
+
+    async Task ShowOkResultModal()
+    {
+        var options = new ModalOptions
+        {
+            HideCloseButton = false,
+            DisableBackgroundCancel = true,
+            HideHeader = true
+        };
+        var loading = Modal.Show<Loading>(string.Empty, options);
+
+        await Task.Delay(5000);
+
+        loading.Close(ModalResult.Ok("Closed with OK result"));
+        var result = await loading.Result;
+        if (result.DataType == typeof(string))
+            _result = result.Data.ToString();
+
+        StateHasChanged();
+    }
+
+    async Task ShowCancelModal()
+    {
+        var options = new ModalOptions
+        {
+            HideCloseButton = false,
+            DisableBackgroundCancel = true,
+            HideHeader = true
+        };
+        var loading = Modal.Show<Loading>(string.Empty, options);
+
+        await Task.Delay(5000);
+
+        loading.Close(ModalResult.Cancel());
+        var result = await loading.Result;
+        if (result.Cancelled)
+            _result = "Closed with Cancelled result";
+
+        StateHasChanged();
+    }
+
+}

--- a/samples/BlazorWebAssembly/Shared/Loading.razor
+++ b/samples/BlazorWebAssembly/Shared/Loading.razor
@@ -1,0 +1,115 @@
+﻿<style>
+    .lds-roller {
+        display: inline-block;
+        position: relative;
+        width: 80px;
+        height: 80px;
+    }
+
+        .lds-roller div {
+            animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+            transform-origin: 40px 40px;
+        }
+
+            .lds-roller div:after {
+                content: " ";
+                display: block;
+                position: absolute;
+                width: 7px;
+                height: 7px;
+                border-radius: 50%;
+                background: #000000;
+                margin: -4px 0 0 -4px;
+            }
+
+            .lds-roller div:nth-child(1) {
+                animation-delay: -0.036s;
+            }
+
+                .lds-roller div:nth-child(1):after {
+                    top: 63px;
+                    left: 63px;
+                }
+
+            .lds-roller div:nth-child(2) {
+                animation-delay: -0.072s;
+            }
+
+                .lds-roller div:nth-child(2):after {
+                    top: 68px;
+                    left: 56px;
+                }
+
+            .lds-roller div:nth-child(3) {
+                animation-delay: -0.108s;
+            }
+
+                .lds-roller div:nth-child(3):after {
+                    top: 71px;
+                    left: 48px;
+                }
+
+            .lds-roller div:nth-child(4) {
+                animation-delay: -0.144s;
+            }
+
+                .lds-roller div:nth-child(4):after {
+                    top: 72px;
+                    left: 40px;
+                }
+
+            .lds-roller div:nth-child(5) {
+                animation-delay: -0.18s;
+            }
+
+                .lds-roller div:nth-child(5):after {
+                    top: 71px;
+                    left: 32px;
+                }
+
+            .lds-roller div:nth-child(6) {
+                animation-delay: -0.216s;
+            }
+
+                .lds-roller div:nth-child(6):after {
+                    top: 68px;
+                    left: 24px;
+                }
+
+            .lds-roller div:nth-child(7) {
+                animation-delay: -0.252s;
+            }
+
+                .lds-roller div:nth-child(7):after {
+                    top: 63px;
+                    left: 17px;
+                }
+
+            .lds-roller div:nth-child(8) {
+                animation-delay: -0.288s;
+            }
+
+                .lds-roller div:nth-child(8):after {
+                    top: 56px;
+                    left: 12px;
+                }
+
+    @@keyframes lds-roller {
+        0% {
+            transform: rotate(0deg);
+        }
+
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+</style>
+
+<div style="width: 500px; height: 500px; line-height: 525px; text-align: center;">
+    <div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+</div>
+
+@code {
+
+    [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
+}

--- a/samples/BlazorWebAssembly/Shared/NavMenu.razor
+++ b/samples/BlazorWebAssembly/Shared/NavMenu.razor
@@ -28,9 +28,12 @@
             </NavLink>
             <NavLink class="nav-link" href="/passingdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data
-            </NavLink>            
+            </NavLink>
             <NavLink class="nav-link" href="/returningdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Returning Data
+            </NavLink>
+            <NavLink class="nav-link" href="/longrunningtask" Match="NavLinkMatch.All">
+                <span class="oi oi-loop-circular" aria-hidden="true"></span> Long running task
             </NavLink>
         </li>
     </ul>

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -24,6 +24,7 @@ namespace Blazored.Modal
         protected override void OnInitialized()
         {
             ((ModalService)ModalService).OnModalInstanceAdded += Update;
+            ((ModalService) ModalService).OnModalCloseRequested += CloseInstance;
             NavigationManager.LocationChanged += CancelModals;
 
             GlobalModalOptions.Class = Class;
@@ -31,6 +32,11 @@ namespace Blazored.Modal
             GlobalModalOptions.HideCloseButton = HideCloseButton;
             GlobalModalOptions.HideHeader = HideHeader;
             GlobalModalOptions.Position = Position;
+        }
+
+        internal void CloseInstance(ModalReference modal, ModalResult result)
+        {
+            DismissInstance(modal.Id, result);
         }
 
         internal void CloseInstance(Guid Id)

--- a/src/Blazored.Modal/ModalReference.cs
+++ b/src/Blazored.Modal/ModalReference.cs
@@ -11,11 +11,24 @@ namespace Blazored.Modal
 
         private Action<ModalResult> Closed;
 
-        public ModalReference(Guid modalInstanceId, RenderFragment modalInstance)
+        private IModalService ModalService { get; }
+
+        public ModalReference(Guid modalInstanceId, RenderFragment modalInstance, IModalService modalService)
         {
             Id = modalInstanceId;
             ModalInstance = modalInstance;
             Closed = HandleClosed;
+            ModalService = modalService;
+        }
+
+        public void Close()
+        {
+            ModalService.Close(this);
+        }
+
+        public void Close(ModalResult result)
+        {
+            ModalService.Close(this, result);
         }
 
         private void HandleClosed(ModalResult obj)

--- a/src/Blazored.Modal/ModalReference.cs
+++ b/src/Blazored.Modal/ModalReference.cs
@@ -11,24 +11,24 @@ namespace Blazored.Modal
 
         private Action<ModalResult> Closed;
 
-        private IModalService ModalService { get; }
+        private readonly ModalService _modalService;
 
-        public ModalReference(Guid modalInstanceId, RenderFragment modalInstance, IModalService modalService)
+        public ModalReference(Guid modalInstanceId, RenderFragment modalInstance, ModalService modalService)
         {
             Id = modalInstanceId;
             ModalInstance = modalInstance;
             Closed = HandleClosed;
-            ModalService = modalService;
+            _modalService = modalService;
         }
 
         public void Close()
         {
-            ModalService.Close(this);
+            _modalService.Close(this);
         }
 
         public void Close(ModalResult result)
         {
-            ModalService.Close(this, result);
+            _modalService.Close(this, result);
         }
 
         private void HandleClosed(ModalResult obj)

--- a/src/Blazored.Modal/ModalReference.cs
+++ b/src/Blazored.Modal/ModalReference.cs
@@ -7,9 +7,9 @@ namespace Blazored.Modal
 {
     public class ModalReference
     {
-        private TaskCompletionSource<ModalResult> _resultCompletion = new TaskCompletionSource<ModalResult>();
+        private readonly TaskCompletionSource<ModalResult> _resultCompletion = new TaskCompletionSource<ModalResult>();
 
-        private Action<ModalResult> Closed;
+        private readonly Action<ModalResult> _closed;
 
         private readonly ModalService _modalService;
 
@@ -17,7 +17,7 @@ namespace Blazored.Modal
         {
             Id = modalInstanceId;
             ModalInstance = modalInstance;
-            Closed = HandleClosed;
+            _closed = HandleClosed;
             _modalService = modalService;
         }
 
@@ -36,14 +36,14 @@ namespace Blazored.Modal
             _ = _resultCompletion.TrySetResult(obj);
         }
 
-        internal Guid Id { get; set; }
-        internal RenderFragment ModalInstance { get; set; }
+        internal Guid Id { get; }
+        internal RenderFragment ModalInstance { get; }
 
         public Task<ModalResult> Result => _resultCompletion.Task;
 
         internal void Dismiss(ModalResult result)
         {
-            Closed.Invoke(result);
+            _closed.Invoke(result);
         }
     }
 }

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -76,18 +76,5 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
         ModalReference Show(Type component, string title, ModalParameters parameters, ModalOptions options);
-
-        /// <summary>
-        /// Closes the <paramref name="modal"/>
-        /// </summary>
-        /// <param name="modal">The <paramref name="modal"/> of the modal to close.</param>
-        void Close(ModalReference modal);
-
-        /// <summary>
-        /// Closes the <paramref name="modal"/>
-        /// </summary>
-        /// <param name="modal">The <paramref name="modal"/> of the modal to close.</param>
-        /// <param name="result">The result of the modal</param>
-        void Close(ModalReference modal, ModalResult result);
     }
 }

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -76,5 +76,18 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
         ModalReference Show(Type component, string title, ModalParameters parameters, ModalOptions options);
+
+        /// <summary>
+        /// Closes the <paramref name="modal"/>
+        /// </summary>
+        /// <param name="modal">The <paramref name="modal"/> of the modal to close.</param>
+        void Close(ModalReference modal);
+
+        /// <summary>
+        /// Closes the <paramref name="modal"/>
+        /// </summary>
+        /// <param name="modal">The <paramref name="modal"/> of the modal to close.</param>
+        /// <param name="result">The result of the modal</param>
+        void Close(ModalReference modal, ModalResult result);
     }
 }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -141,12 +141,12 @@ namespace Blazored.Modal.Services
             return modalReference;
         }
 
-        public void Close(ModalReference modal)
+        internal void Close(ModalReference modal)
         {
             Close(modal, ModalResult.Ok<object>(null));
         }
 
-        public void Close(ModalReference modal, ModalResult result)
+        internal void Close(ModalReference modal, ModalResult result)
         {
             OnModalCloseRequested?.Invoke(modal, result);
         }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -6,6 +6,7 @@ namespace Blazored.Modal.Services
     public class ModalService : IModalService
     {
         internal event Action<ModalReference> OnModalInstanceAdded;
+        internal event Action<ModalReference, ModalResult> OnModalCloseRequested;
 
         /// <summary>
         /// Shows the modal with the component type.
@@ -133,11 +134,21 @@ namespace Blazored.Modal.Services
                 builder.AddAttribute(4, "Id", modalInstanceId);
                 builder.CloseComponent();
             });
-            var modalReference = new ModalReference(modalInstanceId, modalInstance);
+            var modalReference = new ModalReference(modalInstanceId, modalInstance, this);
 
             OnModalInstanceAdded?.Invoke(modalReference);
 
             return modalReference;
+        }
+
+        public void Close(ModalReference modal)
+        {
+            Close(modal, ModalResult.Ok<object>(null));
+        }
+
+        public void Close(ModalReference modal, ModalResult result)
+        {
+            OnModalCloseRequested?.Invoke(modal, result);
         }
     }
 }


### PR DESCRIPTION
This PR closes #120. It adds a `Close()` function to `ModalReference`. Optionally a `ModalResult` can be passed, which I think is handy when having a long-running task that can give some result. 

I added an example that shows the loading dialog while waiting for 5 seconds, as I think this is what people were trying to make in #120.

I added a new function to the `ModalService `that can close a modal using the `ModalReference `instead of the `ModalReference.Id`. The reasoning for this function is because I wanted to keep the arguments used between the `OnModalInstanceAdded` and `OnModalCloseRequested` the same in the `ModalService`. I can understand though if we would rather just use the functions that use the `ModalReference.Id`. Just let me know!