### PR TITLE
Modal service now returns IModalReference instead of ModalReference

### DIFF
--- a/src/Blazored.Modal/IModalReference.cs
+++ b/src/Blazored.Modal/IModalReference.cs
@@ -1,0 +1,13 @@
+﻿using Blazored.Modal.Services;
+using System.Threading.Tasks;
+
+namespace Blazored.Modal
+{
+    public interface IModalReference
+    {
+        Task<ModalResult> Result { get; }
+
+        void Close();
+        void Close(ModalResult result);
+    }
+}

--- a/src/Blazored.Modal/ModalReference.cs
+++ b/src/Blazored.Modal/ModalReference.cs
@@ -5,12 +5,10 @@ using System.Threading.Tasks;
 
 namespace Blazored.Modal
 {
-    public class ModalReference
+    public class ModalReference : IModalReference
     {
         private readonly TaskCompletionSource<ModalResult> _resultCompletion = new TaskCompletionSource<ModalResult>();
-
         private readonly Action<ModalResult> _closed;
-
         private readonly ModalService _modalService;
 
         public ModalReference(Guid modalInstanceId, RenderFragment modalInstance, ModalService modalService)

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -8,27 +8,27 @@ namespace Blazored.Modal.Services
         /// <summary>
         /// Shows a modal containing the specified <typeparamref name="TComponent"/>.
         /// </summary>
-        ModalReference Show<TComponent>() where TComponent : ComponentBase;
+        IModalReference Show<TComponent>() where TComponent : ComponentBase;
 
         /// <summary>
         /// Shows a modal containing a <typeparamref name="TComponent"/> with the specified <paramref name="title"/> .
         /// </summary>
         /// <param name="title">Modal title</param>
-        ModalReference Show<TComponent>(string title) where TComponent : ComponentBase;
+        IModalReference Show<TComponent>(string title) where TComponent : ComponentBase;
 
         /// <summary>
         /// Shows a modal containing a <typeparamref name="TComponent"/> with the specified <paramref name="title"/> and <paramref name="options"/>.
         /// </summary>
         /// <param name="title">Modal title</param>
         /// <param name="options">Options to configure the modal</param>
-        ModalReference Show<TComponent>(string title, ModalOptions options) where TComponent : ComponentBase;
+        IModalReference Show<TComponent>(string title, ModalOptions options) where TComponent : ComponentBase;
 
         /// <summary>
         /// Shows a modal containing a <typeparamref name="TComponent"/> with the specified <paramref name="title"/> and <paramref name="parameters"/>.
         /// </summary>
         /// <param name="title">Modal title</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed</param>
-        ModalReference Show<TComponent>(string title, ModalParameters parameters) where TComponent : ComponentBase;
+        IModalReference Show<TComponent>(string title, ModalParameters parameters) where TComponent : ComponentBase;
 
         /// <summary>
         /// Shows a modal containing a <typeparamref name="TComponent"/> with the specified <paramref name="title"/>,
@@ -37,20 +37,20 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        ModalReference Show<TComponent>(string title, ModalParameters parameters = null, ModalOptions options = null) where TComponent : ComponentBase;
+        IModalReference Show<TComponent>(string title, ModalParameters parameters = null, ModalOptions options = null) where TComponent : ComponentBase;
 
         /// <summary>
         /// Shows a modal containing a <paramref name="component"/>.
         /// </summary>
         /// <param name="component">Type of component to display.</param>
-        ModalReference Show(Type component);
+        IModalReference Show(Type component);
 
         /// <summary>
         /// Shows a modal containing a <paramref name="component"/> with the specified <paramref name="title"/>.
         /// </summary>
         /// <param name="component">Type of component to display.</param>
         /// <param name="title">Modal title.</param>
-        ModalReference Show(Type component, string title);
+        IModalReference Show(Type component, string title);
 
         /// <summary>
         /// Shows a modal containing a <paramref name="component"/> with the specified <paramref name="title"/> and <paramref name="options"/>.
@@ -58,7 +58,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="component">Type of component to display.</param>
         /// <param name="options">Options to configure the modal.</param>
-        ModalReference Show(Type component, string title, ModalOptions options);
+        IModalReference Show(Type component, string title, ModalOptions options);
 
         /// <summary>
         /// Shows a modal containing a <paramref name="component"/> with the specified <paramref name="title"/> and <paramref name="parameters"/>.
@@ -66,7 +66,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="component">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        ModalReference Show(Type component, string title, ModalParameters parameters);
+        IModalReference Show(Type component, string title, ModalParameters parameters);
 
         /// <summary>
         /// Shows a modal containing a <paramref name="component"/> with the specified <paramref name="title"/>, <paramref name="parameters"/>
@@ -75,6 +75,6 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        ModalReference Show(Type component, string title, ModalParameters parameters, ModalOptions options);
+        IModalReference Show(Type component, string title, ModalParameters parameters, ModalOptions options);
     }
 }

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -11,7 +11,7 @@ namespace Blazored.Modal.Services
         /// <summary>
         /// Shows the modal with the component type.
         /// </summary>
-        public ModalReference Show<T>() where T : ComponentBase
+        public IModalReference Show<T>() where T : ComponentBase
         {
             return Show<T>(string.Empty, new ModalParameters(), new ModalOptions());
         }
@@ -20,7 +20,7 @@ namespace Blazored.Modal.Services
         /// Shows the modal with the component type using the specified title.
         /// </summary>
         /// <param name="title">Modal title.</param>
-        public ModalReference Show<T>(string title) where T : ComponentBase
+        public IModalReference Show<T>(string title) where T : ComponentBase
         {
             return Show<T>(title, new ModalParameters(), new ModalOptions());
         }
@@ -30,7 +30,7 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public ModalReference Show<T>(string title, ModalOptions options) where T : ComponentBase
+        public IModalReference Show<T>(string title, ModalOptions options) where T : ComponentBase
         {
             return Show<T>(title, new ModalParameters(), options);
         }
@@ -41,7 +41,7 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        public ModalReference Show<T>(string title, ModalParameters parameters) where T : ComponentBase
+        public IModalReference Show<T>(string title, ModalParameters parameters) where T : ComponentBase
         {
             return Show<T>(title, parameters, new ModalOptions());
         }
@@ -53,7 +53,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public ModalReference Show<T>(string title, ModalParameters parameters, ModalOptions options) where T : ComponentBase
+        public IModalReference Show<T>(string title, ModalParameters parameters, ModalOptions options) where T : ComponentBase
         {
             return Show(typeof(T), title, parameters, options);
         }
@@ -62,7 +62,7 @@ namespace Blazored.Modal.Services
         /// Shows the modal with the specific component type.
         /// </summary>
         /// <param name="contentComponent">Type of component to display.</param>
-        public ModalReference Show(Type contentComponent)
+        public IModalReference Show(Type contentComponent)
         {
             return Show(contentComponent, string.Empty, new ModalParameters(), new ModalOptions());
         }
@@ -72,7 +72,7 @@ namespace Blazored.Modal.Services
         /// </summary>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="title">Modal title.</param>
-        public ModalReference Show(Type contentComponent, string title)
+        public IModalReference Show(Type contentComponent, string title)
         {
             return Show(contentComponent, title, new ModalParameters(), new ModalOptions());
         }
@@ -83,7 +83,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public ModalReference Show(Type contentComponent, string title, ModalOptions options)
+        public IModalReference Show(Type contentComponent, string title, ModalOptions options)
         {
             return Show(contentComponent, title, new ModalParameters(), options);
         }
@@ -95,7 +95,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="contentComponent">Type of component to display.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
-        public ModalReference Show(Type contentComponent, string title, ModalParameters parameters)
+        public IModalReference Show(Type contentComponent, string title, ModalParameters parameters)
         {
             return Show(contentComponent, title, parameters, new ModalOptions());
         }
@@ -107,7 +107,7 @@ namespace Blazored.Modal.Services
         /// <param name="title">Modal title.</param>
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
-        public ModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options)
+        public IModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options)
         {
             if (!typeof(ComponentBase).IsAssignableFrom(contentComponent))
             {


### PR DESCRIPTION
Resolves #170 

The `ModalService` now returns an `IModalReference` instead of the concrete `ModalReference` type.