### PR TITLE
Feature/animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,33 @@ Or in the `Modal.Show()` method:
 }
 ```
 
+#### Animation
+By default, Blazored Modal supports 2 different animations: Fade-in and Fade-out. These 2 can also be combined to both fade-in and fade-out. By default no animation is used. If you want to use an animation for the modal, you can set one globally or per modal. 
+
+##### Setting Animation Globally
+
+To set a global animation for all modals in your application, you can set the `Animation` parameter on the `BlazoredModal` component in your `MainLayout`. Below sets a Fade-in animation with a duration of 2 seconds.
+
+```razor
+@inherits LayoutComponentBase
+
+<BlazoredModal Animation="@(new ModalAnimation(ModalAnimationType.FadeIn, 2))"/>
+
+<!-- Other code removed for brevity -->
+```
+
+##### Setting Animation Per Modal
+
+To set the Animation of a specific modal instance you can pass in a `ModalOptions` object when calling `Show`. Below exapmle will add a Fade-in and Fade-out animation, which will take 1 second each.
+
+```razor
+var options = new ModalOptions { Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 1)};
+
+_ = Modal.Show<Confirm>("My Modal", options);
+```
+
+
+
 ### Multiple Modals
 
 It's possible to have multiple active modal instances at a time. You can find a working example of this in the sample projects but here is some sample code.

--- a/README.md
+++ b/README.md
@@ -384,11 +384,11 @@ Or in the `Modal.Show()` method:
 #### Animation
 The modal also supports some animations.
 
-The following animation types are available out of the box: `ModalAnimationType.FadeIn`, `ModalAnimationType.FadeOut` and `ModalAnimationType.FadeInOut`.
+The following animation types are available out of the box: `ModalAnimation.FadeIn`, `ModalAnimation.FadeOut` and `ModalAnimation.FadeInOut`.
 
 Use the `Animation` parameter to set the custom styling globally:
 
-`<BlazoredModal Animation="@(new ModalAnimation(ModalAnimationType.FadeIn, 2))"/>`
+`<BlazoredModal Animation="@ModalAnimation.FadeIn(2)"/>`
 
 Or in the `Modal.Show()` method:
 
@@ -398,7 +398,7 @@ Or in the `Modal.Show()` method:
     {
         var options = new ModalOptions() 
         { 
-            Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 1)
+            Animation = ModalAnimation.FadeInOut(1)
         };
 
         Modal.Show<Movies>("My Movies", options);

--- a/README.md
+++ b/README.md
@@ -382,31 +382,29 @@ Or in the `Modal.Show()` method:
 ```
 
 #### Animation
-By default, Blazored Modal supports 2 different animations: Fade-in and Fade-out. These 2 can also be combined to both fade-in and fade-out. By default no animation is used. If you want to use an animation for the modal, you can set one globally or per modal. 
+The modal also supports some animations.
 
-##### Setting Animation Globally
+The following animation types are available out of the box: `ModalAnimationType.FadeIn`, `ModalAnimationType.FadeOut` and `ModalAnimationType.FadeInOut`.
 
-To set a global animation for all modals in your application, you can set the `Animation` parameter on the `BlazoredModal` component in your `MainLayout`. Below sets a Fade-in animation with a duration of 2 seconds.
+Use the `Animation` parameter to set the custom styling globally:
 
-```razor
-@inherits LayoutComponentBase
+`<BlazoredModal Animation="@(new ModalAnimation(ModalAnimationType.FadeIn, 2))"/>`
 
-<BlazoredModal Animation="@(new ModalAnimation(ModalAnimationType.FadeIn, 2))"/>
-
-<!-- Other code removed for brevity -->
-```
-
-##### Setting Animation Per Modal
-
-To set the Animation of a specific modal instance you can pass in a `ModalOptions` object when calling `Show`. Below exapmle will add a Fade-in and Fade-out animation, which will take 1 second each.
+Or in the `Modal.Show()` method:
 
 ```razor
-var options = new ModalOptions { Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 1)};
+@code {
+    void ShowModal()
+    {
+        var options = new ModalOptions() 
+        { 
+            Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 1)
+        };
 
-_ = Modal.Show<Confirm>("My Modal", options);
+        Modal.Show<Movies>("My Movies", options);
+    }
+}
 ```
-
-
 
 ### Multiple Modals
 

--- a/docs/src/customisation-options/animation.md
+++ b/docs/src/customisation-options/animation.md
@@ -1,0 +1,29 @@
+# Animation
+How to customise the animation of modals.
+
+---
+
+By default, Blazored Modal supports 2 different animations: Fade-in and Fade-out. These 2 can also be combined to both fade-in and fade-out. By default no animation is used. If you want to use an animation for the modal, you can set one globally or per modal. 
+
+## Setting Animation Globally
+
+To set a global animation for all modals in your application, you can set the `Animation` parameter on the `BlazoredModal` component in your `MainLayout`. Below sets a Fade-in animation with a duration of 2 seconds.
+
+```html
+@inherits LayoutComponentBase
+
+<BlazoredModal Animation="@(new ModalAnimation(ModalAnimationType.FadeIn, 2))"/>
+
+<!-- Other code removed for brevity -->
+```
+
+## Setting Animation Per Modal
+
+To set the Animation of a specific modal instance you can pass in a `ModalOptions` object when calling `Show`. Below exapmle will add a Fade-in and Fade-out animation, which will take 1 second each.
+
+```csharp
+var options = new ModalOptions { Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 1)};
+
+_ = Modal.Show<Confirm>("My Modal", options);
+```
+

--- a/docs/src/customisation-options/animation.md
+++ b/docs/src/customisation-options/animation.md
@@ -12,7 +12,7 @@ To set a global animation for all modals in your application, you can set the `A
 ```html
 @inherits LayoutComponentBase
 
-<BlazoredModal Animation="@(new ModalAnimation(ModalAnimationType.FadeIn, 2))"/>
+<BlazoredModal Animation="@ModalAnimation.FadeIn(2)"/>
 
 <!-- Other code removed for brevity -->
 ```
@@ -22,7 +22,7 @@ To set a global animation for all modals in your application, you can set the `A
 To set the Animation of a specific modal instance you can pass in a `ModalOptions` object when calling `Show`. Below exapmle will add a Fade-in and Fade-out animation, which will take 1 second each.
 
 ```csharp
-var options = new ModalOptions { Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 1)};
+var options = new ModalOptions { Animation = ModalAnimation.FadeInOut(1)};
 
 _ = Modal.Show<Confirm>("My Modal", options);
 ```

--- a/docs/src/customisation-options/toc.yml
+++ b/docs/src/customisation-options/toc.yml
@@ -28,3 +28,5 @@
       href: hide-header.md
     - name: Hide Close Button
       href: hide-close-button.md
+    - name: Animation
+      href: animation.md

--- a/docs/src/getting-started/toc.yml
+++ b/docs/src/getting-started/toc.yml
@@ -28,3 +28,5 @@
       href: ../customisation-options/hide-header.md
     - name: Hide Close Button
       href: ../customisation-options/hide-close-button.md
+    - name: Animation
+      href: ../customisation-options/animation.md

--- a/docs/src/usage/toc.yml
+++ b/docs/src/usage/toc.yml
@@ -28,3 +28,5 @@
       href: ../customisation-options/hide-header.md
     - name: Hide Close Button
       href: ../customisation-options/hide-close-button.md
+    - name: Animation
+      href: ../customisation-options/animation.md

--- a/samples/BlazorServer/Pages/Animation.razor
+++ b/samples/BlazorServer/Pages/Animation.razor
@@ -27,7 +27,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("<BlazoredModal Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)  />")
+                @("<BlazoredModal Animation=\"new ModalAnimation(ModalAnimationType.FadeIn, 2)\"/> ")
             </code>
         </p>
     </div>

--- a/samples/BlazorServer/Pages/Animation.razor
+++ b/samples/BlazorServer/Pages/Animation.razor
@@ -1,0 +1,54 @@
+﻿@page "/animation"
+@inject IModalService Modal
+
+<h1>Animating the modal</h1>
+
+<hr class="mb-5" />
+
+<p>
+    By default, the modal is shown without animation. The modal can be set to no animation, Fade in, Fade out or both.
+</p>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting on a per modal basis</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("var options = new ModalOptions() { Animation = ModalAnimation.FadeIn };")
+                <br />
+                @("Modal.Show<Confirm>(\"Animation: Fade-In\", options);")
+            </code>
+        </p>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting globally for all modals</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("<BlazoredModal Animation=\"ModalAnimation.FadeIn\" />")
+            </code>
+        </p>
+    </div>
+</div>
+
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeIn))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeOut))" class="btn btn-secondary">Fade-Out</button>
+<button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
+
+@code {
+
+    void AnimationDefault()
+    {
+        Modal.Show<Confirm>("Default Animation");
+    }
+
+    void AnimationCustom(ModalAnimation animation)
+    {
+        var options = new ModalOptions { Animation = animation };
+
+        Modal.Show<Confirm>($"Animation: {animation}", options);
+    }
+}

--- a/samples/BlazorServer/Pages/Animation.razor
+++ b/samples/BlazorServer/Pages/Animation.razor
@@ -35,10 +35,10 @@
 
 <input type="number" @bind-value="@duration" />
 
-<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeIn))" class="btn btn-secondary">Fade-In</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeOut))" class="btn btn-secondary">Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeIn, duration)))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeOut, duration)))" class="btn btn-secondary">Fade-Out</button>
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeInOut, duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
 @code {
     private double duration = 1.0;
@@ -48,16 +48,11 @@
         Modal.Show<Confirm>("Default Animation");
     }
 
-    void AnimationCustom(ModalAnimationType type)
+    void AnimationCustom(ModalAnimation animation)
     {
-        var animation = new ModalAnimation
-        {
-            Type = type,
-            Duration = duration
-        };
 
         var options = new ModalOptions { Animation = animation };
 
-        Modal.Show<Confirm>($"Animation: {animation}", options);
+        Modal.Show<Confirm>($"Animation: {animation.Type}", options);
     }
 }

--- a/samples/BlazorServer/Pages/Animation.razor
+++ b/samples/BlazorServer/Pages/Animation.razor
@@ -14,7 +14,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var options = new ModalOptions() { Animation = ModalAnimation.FadeIn };")
+                @("var options = new ModalOptions() { Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2) };")
                 <br />
                 @("Modal.Show<Confirm>(\"Animation: Fade-In\", options);")
             </code>
@@ -27,7 +27,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("<BlazoredModal Animation=\"ModalAnimation.FadeIn\" />")
+                @("<BlazoredModal Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)  />")
             </code>
         </p>
     </div>
@@ -40,6 +40,12 @@
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
 <button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeInOut, duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
+<p>
+    It is also possible to have multiple modals (like in the Multiple Modals example) with different animations. With the below modal, the first modal will only fade-in with a duration of 2 seconds. The second modal will fade-in and fade-out in 5.0 seconds.
+</p>
+
+<button @onclick="@MultipleModals" class="btn btn-primary">Multiple Modals</button>
+
 @code {
     private double duration = 1.0;
 
@@ -50,9 +56,18 @@
 
     void AnimationCustom(ModalAnimation animation)
     {
-
         var options = new ModalOptions { Animation = animation };
 
         Modal.Show<Confirm>($"Animation: {animation.Type}", options);
+    }
+
+    void MultipleModals()
+    {
+        var options = new ModalOptions
+        {
+            Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)
+        };
+
+        Modal.Show<YesNoPromptAnimation>("Multiple Modals", options);
     }
 }

--- a/samples/BlazorServer/Pages/Animation.razor
+++ b/samples/BlazorServer/Pages/Animation.razor
@@ -14,7 +14,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var options = new ModalOptions() { Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2) };")
+                @("var options = new ModalOptions() { Animation = ModalAnimation.FadeIn(2) };")
                 <br />
                 @("Modal.Show<Confirm>(\"Animation: Fade-In\", options);")
             </code>
@@ -27,7 +27,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("<BlazoredModal Animation=\"new ModalAnimation(ModalAnimationType.FadeIn, 2)\"/> ")
+                @("<BlazoredModal Animation=\"@ModalAnimation.FadeIn(2)\"/> ")
             </code>
         </p>
     </div>
@@ -35,10 +35,10 @@
 
 <input type="number" @bind-value="@duration" />
 
-<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeIn, duration)))" class="btn btn-secondary">Fade-In</button>
-<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeOut, duration)))" class="btn btn-secondary">Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeIn(duration)))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeOut(duration)))" class="btn btn-secondary">Fade-Out</button>
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
-<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeInOut, duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeInOut(duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
 <p>
     It is also possible to have multiple modals (like in the Multiple Modals example) with different animations. With the below modal, the first modal will only fade-in with a duration of 2 seconds. The second modal will fade-in and fade-out in 5.0 seconds.
@@ -65,7 +65,7 @@
     {
         var options = new ModalOptions
         {
-            Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)
+            Animation = ModalAnimation.FadeIn(2)
         };
 
         Modal.Show<YesNoPromptAnimation>("Multiple Modals", options);

--- a/samples/BlazorServer/Pages/Animation.razor
+++ b/samples/BlazorServer/Pages/Animation.razor
@@ -33,20 +33,29 @@
     </div>
 </div>
 
-<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeIn))" class="btn btn-secondary">Fade-In</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeOut))" class="btn btn-secondary">Fade-Out</button>
+<input type="number" @bind-value="@duration" />
+
+<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeIn))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeOut))" class="btn btn-secondary">Fade-Out</button>
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
 @code {
+    private double duration = 1.0;
 
     void AnimationDefault()
     {
         Modal.Show<Confirm>("Default Animation");
     }
 
-    void AnimationCustom(ModalAnimation animation)
+    void AnimationCustom(ModalAnimationType type)
     {
+        var animation = new ModalAnimation
+        {
+            Type = type,
+            Duration = duration
+        };
+
         var options = new ModalOptions { Animation = animation };
 
         Modal.Show<Confirm>($"Animation: {animation}", options);

--- a/samples/BlazorServer/Shared/NavMenu.razor
+++ b/samples/BlazorServer/Shared/NavMenu.razor
@@ -35,6 +35,9 @@
             <NavLink class="nav-link" href="/longrunningtask" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-circular" aria-hidden="true"></span> Long running task
             </NavLink>
+            <NavLink class="nav-link" href="/animation" Match="NavLinkMatch.All">
+                <span class="oi oi-aperture" aria-hidden="true"></span> Animation
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
@@ -1,0 +1,29 @@
+﻿@inject IModalService ModalService
+
+<div>
+    <p>Are you sure you want to delete the record?</p>
+
+    <button @onclick="Yes" class="btn btn-outline-danger">Yes</button>
+    <button @onclick="No" class="btn btn-primary">No</button>
+</div>
+
+@code {
+
+    [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
+
+    async Task Yes()
+    {
+        var options = new ModalOptions { Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 5) };
+
+        var confirmationModal = ModalService.Show<Confirm>("Second Modal", options);
+        var result = await confirmationModal.Result;
+
+        if (result.Cancelled)
+            return;
+
+        BlazoredModal.Close();
+    }
+
+    void No() => BlazoredModal.Cancel();
+
+}

--- a/samples/BlazorWebAssembly/Pages/Animation.razor
+++ b/samples/BlazorWebAssembly/Pages/Animation.razor
@@ -27,7 +27,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("<BlazoredModal Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)  />")
+                @("<BlazoredModal Animation=\"new ModalAnimation(ModalAnimationType.FadeIn, 2)\"/> ")
             </code>
         </p>
     </div>

--- a/samples/BlazorWebAssembly/Pages/Animation.razor
+++ b/samples/BlazorWebAssembly/Pages/Animation.razor
@@ -1,0 +1,54 @@
+﻿@page "/animation"
+@inject IModalService Modal
+
+<h1>Animating the modal</h1>
+
+<hr class="mb-5" />
+
+<p>
+    By default, the modal is shown without animation. The modal can be set to no animation, Fade in, Fade out or both.
+</p>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting on a per modal basis</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("var options = new ModalOptions() { Animation = ModalAnimation.FadeIn };")
+                <br />
+                @("Modal.Show<Confirm>(\"Animation: Fade-In\", options);")
+            </code>
+        </p>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting globally for all modals</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("<BlazoredModal Animation=\"ModalAnimation.FadeIn\" />")
+            </code>
+        </p>
+    </div>
+</div>
+
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeIn))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeOut))" class="btn btn-secondary">Fade-Out</button>
+<button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
+
+@code {
+
+    void AnimationDefault()
+    {
+        Modal.Show<Confirm>("Default Animation");
+    }
+
+    void AnimationCustom(ModalAnimation animation)
+    {
+        var options = new ModalOptions { Animation = animation };
+
+        Modal.Show<Confirm>($"Animation: {animation}", options);
+    }
+}

--- a/samples/BlazorWebAssembly/Pages/Animation.razor
+++ b/samples/BlazorWebAssembly/Pages/Animation.razor
@@ -35,29 +35,26 @@
 
 <input type="number" @bind-value="@duration" />
 
-<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeIn))" class="btn btn-secondary">Fade-In</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeOut))" class="btn btn-secondary">Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeIn, duration)))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeOut, duration)))" class="btn btn-secondary">Fade-Out</button>
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeInOut, duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
 @code {
     private double duration = 1.0;
 
     void AnimationDefault()
     {
-        Modal.Show<Confirm>("Default Animation");
+        Modal.Show<Confirm>
+            ("Default Animation");
     }
 
-    void AnimationCustom(ModalAnimationType type)
+    void AnimationCustom(ModalAnimation animation)
     {
-        var animation = new ModalAnimation
-        {
-            Type = type,
-            Duration = duration
-        };
 
         var options = new ModalOptions { Animation = animation };
 
-        Modal.Show<Confirm>($"Animation: {animation}", options);
+        Modal.Show<Confirm>
+            ($"Animation: {animation.Type}", options);
     }
 }

--- a/samples/BlazorWebAssembly/Pages/Animation.razor
+++ b/samples/BlazorWebAssembly/Pages/Animation.razor
@@ -14,7 +14,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var options = new ModalOptions() { Animation = ModalAnimation.FadeIn };")
+                @("var options = new ModalOptions() { Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2) };")
                 <br />
                 @("Modal.Show<Confirm>(\"Animation: Fade-In\", options);")
             </code>
@@ -27,7 +27,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("<BlazoredModal Animation=\"ModalAnimation.FadeIn\" />")
+                @("<BlazoredModal Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)  />")
             </code>
         </p>
     </div>
@@ -40,21 +40,34 @@
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
 <button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeInOut, duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
+<p>
+    It is also possible to have multiple modals (like in the Multiple Modals example) with different animations. With the below modal, the first modal will only fade-in with a duration of 2 seconds. The second modal will fade-in and fade-out in 5.0 seconds.
+</p>
+
+<button @onclick="@MultipleModals" class="btn btn-primary">Multiple Modals</button>
+
 @code {
     private double duration = 1.0;
 
     void AnimationDefault()
     {
-        Modal.Show<Confirm>
-            ("Default Animation");
+        Modal.Show<Confirm>("Default Animation");
     }
 
     void AnimationCustom(ModalAnimation animation)
     {
-
         var options = new ModalOptions { Animation = animation };
 
-        Modal.Show<Confirm>
-            ($"Animation: {animation.Type}", options);
+        Modal.Show<Confirm>($"Animation: {animation.Type}", options);
+    }
+
+    void MultipleModals()
+    {
+        var options = new ModalOptions
+        {
+            Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)
+        };
+
+        Modal.Show<YesNoPromptAnimation>("Multiple Modals", options);
     }
 }

--- a/samples/BlazorWebAssembly/Pages/Animation.razor
+++ b/samples/BlazorWebAssembly/Pages/Animation.razor
@@ -14,7 +14,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var options = new ModalOptions() { Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2) };")
+                @("var options = new ModalOptions() { Animation = ModalAnimation.FadeIn(2) };")
                 <br />
                 @("Modal.Show<Confirm>(\"Animation: Fade-In\", options);")
             </code>
@@ -27,7 +27,7 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("<BlazoredModal Animation=\"new ModalAnimation(ModalAnimationType.FadeIn, 2)\"/> ")
+                @("<BlazoredModal Animation=\"@ModalAnimation.FadeIn(2)\"/> ")
             </code>
         </p>
     </div>
@@ -35,10 +35,10 @@
 
 <input type="number" @bind-value="@duration" />
 
-<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeIn, duration)))" class="btn btn-secondary">Fade-In</button>
-<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeOut, duration)))" class="btn btn-secondary">Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeIn(duration)))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeOut(duration)))" class="btn btn-secondary">Fade-Out</button>
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
-<button @onclick="@(() => AnimationCustom(new ModalAnimation(ModalAnimationType.FadeInOut, duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeInOut(duration)))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
 <p>
     It is also possible to have multiple modals (like in the Multiple Modals example) with different animations. With the below modal, the first modal will only fade-in with a duration of 2 seconds. The second modal will fade-in and fade-out in 5.0 seconds.
@@ -65,7 +65,7 @@
     {
         var options = new ModalOptions
         {
-            Animation = new ModalAnimation(ModalAnimationType.FadeIn, 2)
+            Animation = ModalAnimation.FadeIn(2)
         };
 
         Modal.Show<YesNoPromptAnimation>("Multiple Modals", options);

--- a/samples/BlazorWebAssembly/Pages/Animation.razor
+++ b/samples/BlazorWebAssembly/Pages/Animation.razor
@@ -33,20 +33,29 @@
     </div>
 </div>
 
-<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeIn))" class="btn btn-secondary">Fade-In</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeOut))" class="btn btn-secondary">Fade-Out</button>
+<input type="number" @bind-value="@duration" />
+
+<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeIn))" class="btn btn-secondary">Fade-In</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeOut))" class="btn btn-secondary">Fade-Out</button>
 <button @onclick="AnimationDefault" class="btn btn-primary">Globally set value (default no animation)</button>
-<button @onclick="@(() => AnimationCustom(ModalAnimation.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
+<button @onclick="@(() => AnimationCustom(ModalAnimationType.FadeInOut))" class="btn btn-secondary">Fade-in Fade-Out</button>
 
 @code {
+    private double duration = 1.0;
 
     void AnimationDefault()
     {
         Modal.Show<Confirm>("Default Animation");
     }
 
-    void AnimationCustom(ModalAnimation animation)
+    void AnimationCustom(ModalAnimationType type)
     {
+        var animation = new ModalAnimation
+        {
+            Type = type,
+            Duration = duration
+        };
+
         var options = new ModalOptions { Animation = animation };
 
         Modal.Show<Confirm>($"Animation: {animation}", options);

--- a/samples/BlazorWebAssembly/Shared/NavMenu.razor
+++ b/samples/BlazorWebAssembly/Shared/NavMenu.razor
@@ -35,6 +35,9 @@
             <NavLink class="nav-link" href="/longrunningtask" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-circular" aria-hidden="true"></span> Long running task
             </NavLink>
+            <NavLink class="nav-link" href="/animation" Match="NavLinkMatch.All">
+                <span class="oi oi-aperture" aria-hidden="true"></span> Animation
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
@@ -1,0 +1,29 @@
+﻿@inject IModalService ModalService
+
+<div>
+    <p>Are you sure you want to delete the record?</p>
+
+    <button @onclick="Yes" class="btn btn-outline-danger">Yes</button>
+    <button @onclick="No" class="btn btn-primary">No</button>
+</div>
+
+@code {
+
+    [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
+
+    async Task Yes()
+    {
+        var options = new ModalOptions { Animation = new ModalAnimation(ModalAnimationType.FadeInOut, 5) };
+
+        var confirmationModal = ModalService.Show<Confirm>("Second Modal", options);
+        var result = await confirmationModal.Result;
+
+        if (result.Cancelled)
+            return;
+
+        BlazoredModal.Close();
+    }
+
+    void No() => BlazoredModal.Cancel();
+
+}

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -20,6 +20,7 @@ namespace Blazored.Modal
         [Parameter] public bool? DisableBackgroundCancel { get; set; }
         [Parameter] public ModalPosition? Position { get; set; }
         [Parameter] public string Class { get; set; }
+        [Parameter] public ModalAnimation Animation { get; set; }
 
         private readonly Collection<ModalReference> Modals = new Collection<ModalReference>();
         private readonly ModalOptions GlobalModalOptions = new ModalOptions();
@@ -35,6 +36,7 @@ namespace Blazored.Modal
             GlobalModalOptions.HideCloseButton = HideCloseButton;
             GlobalModalOptions.HideHeader = HideHeader;
             GlobalModalOptions.Position = Position;
+            GlobalModalOptions.Animation = Animation;
         }
 
         internal async void CloseInstance(ModalReference modal, ModalResult result)

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -4,7 +4,7 @@
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="@Class" @onkeyup="HandleWrapperKeyUp">
+    <div class="@Class @AnimationClass" @onkeyup="HandleWrapperKeyUp">
         @if (!HideHeader)
         {
             <div class="blazored-modal-header">
@@ -36,6 +36,7 @@
 
     private string Position { get; set; }
     private string Class { get; set; }
+    private string AnimationClass { get; set; }
     private bool HideHeader { get; set; }
     private bool HideCloseButton { get; set; }
     private bool DisableBackgroundCancel { get; set; }
@@ -79,6 +80,14 @@
     /// <param name="modalResult"></param>
     public async Task Close(ModalResult modalResult)
     {
+        // Fade out the modal, and after that actually remove it
+        if(Options.Animation == ModalAnimation.FadeOut || Options.Animation == ModalAnimation.FadeInOut)
+        {
+            AnimationClass = "blazored-modal-fade-out";
+            StateHasChanged();
+            await Task.Delay(1100); // Needs to be a bit more than the animation time because of delays in the animation being applied, I think.
+        }
+
         await Parent.DismissInstance(Id, modalResult);
     }
 
@@ -87,13 +96,14 @@
     /// </summary>
     public async Task Cancel()
     {
-        await Parent.DismissInstance(Id, ModalResult.Cancel());
+        await Close(ModalResult.Cancel());
     }
 
     private void ConfigureInstance()
     {
         Position = SetPosition();
         Class = SetClass();
+        AnimationClass = SetAnimationClass();
         HideHeader = SetHideHeader();
         HideCloseButton = SetHideCloseButton();
         DisableBackgroundCancel = SetDisableBackgroundCancel();
@@ -151,6 +161,25 @@
         return "blazored-modal";
     }
 
+    private string SetAnimationClass()
+    {
+        switch (Options.Animation)
+        {
+            case ModalAnimation.None:
+                return string.Empty;
+            case ModalAnimation.FadeIn:
+            case ModalAnimation.FadeInOut:
+                return "blazored-modal-fade-in";
+            case ModalAnimation.FadeOut:
+                //return "blazored-modal-fade-out";
+                return string.Empty;
+                //return "blazored-modal-fade-in-out";
+                return string.Empty;
+            default:
+                return string.Empty;
+        }
+    }
+
     private bool SetHideHeader()
     {
         if (Options.HideHeader.HasValue)
@@ -188,7 +217,7 @@
     {
         if (DisableBackgroundCancel) return;
 
-        await Parent.CancelInstance(Id);
+        await Cancel();
     }
 
 }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -1,10 +1,10 @@
 ﻿<style>
     #_@(Id.ToString("N")).blazored-modal-fade-in {
-        animation: @(Options?.Animation?.Duration)s ease-out 0s ModalFadeIn;
+        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeIn;
     }
 
     #_@(Id.ToString("N")).blazored-modal-fade-out {
-        animation: @(Options?.Animation?.Duration)s ease-out 0s ModalFadeOut;
+        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeOut;
         opacity: 0;
     }
 

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -1,10 +1,10 @@
 ﻿<style>
     #_@(Id.ToString("N")).blazored-modal-fade-in {
-        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeIn;
+        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation?.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeIn;
     }
 
     #_@(Id.ToString("N")).blazored-modal-fade-out {
-        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeOut;
+        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation?.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeOut;
         opacity: 0;
     }
 

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -1,9 +1,9 @@
 ﻿<style>
-    .blazored-modal-fade-in {
+    #_@(Id.ToString("N")).blazored-modal-fade-in {
         animation: @(Options?.Animation?.Duration)s ease-out 0s ModalFadeIn;
     }
 
-    .blazored-modal-fade-out {
+    #_@(Id.ToString("N")).blazored-modal-fade-out {
         animation: @(Options?.Animation?.Duration)s ease-out 0s ModalFadeOut;
         opacity: 0;
     }
@@ -33,7 +33,7 @@
 
     <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-    <div class="@Class @AnimationClass" @onkeyup="HandleWrapperKeyUp">
+    <div id="_@Id.ToString("N")"class="@Class @AnimationClass" @onkeyup="HandleWrapperKeyUp">
         @if (!HideHeader)
         {
             <div class="blazored-modal-header">

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -85,7 +85,7 @@
         {
             AnimationClass = "blazored-modal-fade-out";
             StateHasChanged();
-            await Task.Delay(1100); // Needs to be a bit more than the animation time because of delays in the animation being applied, I think.
+            await Task.Delay(1100); // Needs to be a bit more than the animation time because of delays in the animation being applied between server and client (at least when using blazor server side), I think.
         }
 
         await Parent.DismissInstance(Id, modalResult);

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -1,4 +1,33 @@
-﻿@inject IJSRuntime JSRuntime
+﻿<style>
+    .blazored-modal-fade-in {
+        animation: @(Options?.Animation?.Duration)s ease-out 0s ModalFadeIn;
+    }
+
+    .blazored-modal-fade-out {
+        animation: @(Options?.Animation?.Duration)s ease-out 0s ModalFadeOut;
+        opacity: 0;
+    }
+
+    @@keyframes ModalFadeIn {
+        0% {
+            opacity: 0;
+        }
+
+        100% {
+            opacity: 1;
+        }
+    }
+
+    @@keyframes ModalFadeOut {
+        0% {
+            opacity: 1;
+        }
+
+        100% {
+            opacity: 0;
+        }
+    }
+</style>
 
 <div class="blazored-modal-container @Position" @ref="_modalReference">
 
@@ -24,200 +53,3 @@
         </div>
     </div>
 </div>
-
-@code {
-    [CascadingParameter] private BlazoredModal Parent { get; set; }
-    [CascadingParameter] private ModalOptions GlobalModalOptions { get; set; }
-
-    [Parameter] public ModalOptions Options { get; set; }
-    [Parameter] public string Title { get; set; }
-    [Parameter] public RenderFragment Content { get; set; }
-    [Parameter] public Guid Id { get; set; }
-
-    private string Position { get; set; }
-    private string Class { get; set; }
-    private string AnimationClass { get; set; }
-    private bool HideHeader { get; set; }
-    private bool HideCloseButton { get; set; }
-    private bool DisableBackgroundCancel { get; set; }
-
-    private ElementReference _modalReference;
-
-    protected override void OnInitialized()
-    {
-        ConfigureInstance();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await JSRuntime.InvokeVoidAsync("BlazoredModal.activateFocusTrap", _modalReference, Id);
-        }
-    }
-
-    /// <summary>
-    /// Sets the title for the modal being displayed
-    /// </summary>
-    /// <param name="title">Text to display as the title of the modal</param>
-    public void SetTitle(string title)
-    {
-        Title = title;
-        StateHasChanged();
-    }
-
-    /// <summary>
-    /// Closes the modal with a default Ok result />.
-    /// </summary>
-    public async Task Close()
-    {
-        await Close(ModalResult.Ok<object>(null));
-    }
-
-    /// <summary>
-    /// Closes the modal with the specified <paramref name="modalResult"/>.
-    /// </summary>
-    /// <param name="modalResult"></param>
-    public async Task Close(ModalResult modalResult)
-    {
-        // Fade out the modal, and after that actually remove it
-        if(Options.Animation == ModalAnimation.FadeOut || Options.Animation == ModalAnimation.FadeInOut)
-        {
-            AnimationClass = "blazored-modal-fade-out";
-            StateHasChanged();
-            await Task.Delay(1100); // Needs to be a bit more than the animation time because of delays in the animation being applied between server and client (at least when using blazor server side), I think.
-        }
-
-        await Parent.DismissInstance(Id, modalResult);
-    }
-
-    /// <summary>
-    /// Closes the modal and returns a cancelled ModalResult.
-    /// </summary>
-    public async Task Cancel()
-    {
-        await Close(ModalResult.Cancel());
-    }
-
-    private void ConfigureInstance()
-    {
-        Position = SetPosition();
-        Class = SetClass();
-        AnimationClass = SetAnimationClass();
-        HideHeader = SetHideHeader();
-        HideCloseButton = SetHideCloseButton();
-        DisableBackgroundCancel = SetDisableBackgroundCancel();
-    }
-
-    private string SetPosition()
-    {
-        ModalPosition position;
-        if (Options.Position.HasValue)
-        {
-            position = Options.Position.Value;
-        }
-        else if (GlobalModalOptions.Position.HasValue)
-        {
-            position = GlobalModalOptions.Position.Value;
-        }
-        else
-        {
-            position = ModalPosition.Center;
-        }
-
-        switch (position)
-        {
-            case ModalPosition.Center:
-                return "blazored-modal-center";
-            case ModalPosition.TopLeft:
-                return "blazored-modal-topleft";
-            case ModalPosition.TopRight:
-                return "blazored-modal-topright";
-            case ModalPosition.BottomLeft:
-                return "blazored-modal-bottomleft";
-            case ModalPosition.BottomRight:
-                return "blazored-modal-bottomright";
-            default:
-                return "blazored-modal-center";
-        }
-    }
-
-    private async Task HandleWrapperKeyUp(KeyboardEventArgs e)
-    {
-        if (e.Code == "Escape")
-        {
-            await Parent.DismissInstance(Id, ModalResult.Cancel());
-        }
-    }
-
-    private string SetClass()
-    {
-        if (!string.IsNullOrWhiteSpace(Options.Class))
-            return Options.Class;
-
-        if (!string.IsNullOrWhiteSpace(GlobalModalOptions.Class))
-            return GlobalModalOptions.Class;
-
-        return "blazored-modal";
-    }
-
-    private string SetAnimationClass()
-    {
-        switch (Options.Animation)
-        {
-            case ModalAnimation.None:
-                return string.Empty;
-            case ModalAnimation.FadeIn:
-            case ModalAnimation.FadeInOut:
-                return "blazored-modal-fade-in";
-            case ModalAnimation.FadeOut:
-                //return "blazored-modal-fade-out";
-                return string.Empty;
-                //return "blazored-modal-fade-in-out";
-                return string.Empty;
-            default:
-                return string.Empty;
-        }
-    }
-
-    private bool SetHideHeader()
-    {
-        if (Options.HideHeader.HasValue)
-            return Options.HideHeader.Value;
-
-        if (GlobalModalOptions.HideHeader.HasValue)
-            return GlobalModalOptions.HideHeader.Value;
-
-        return false;
-    }
-
-    private bool SetHideCloseButton()
-    {
-        if (Options.HideCloseButton.HasValue)
-            return Options.HideCloseButton.Value;
-
-        if (GlobalModalOptions.HideCloseButton.HasValue)
-            return GlobalModalOptions.HideCloseButton.Value;
-
-        return false;
-    }
-
-    private bool SetDisableBackgroundCancel()
-    {
-        if (Options.DisableBackgroundCancel.HasValue)
-            return Options.DisableBackgroundCancel.Value;
-
-        if (GlobalModalOptions.DisableBackgroundCancel.HasValue)
-            return GlobalModalOptions.DisableBackgroundCancel.Value;
-
-        return false;
-    }
-
-    private async Task HandleBackgroundClick()
-    {
-        if (DisableBackgroundCancel) return;
-
-        await Cancel();
-    }
-
-}

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -1,0 +1,207 @@
+﻿using Blazored.Modal.Services;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+
+namespace Blazored.Modal
+{
+    public partial class BlazoredModalInstance
+    {
+        [Inject] private IJSRuntime JSRuntime { get; set; }
+        [CascadingParameter] private BlazoredModal Parent { get; set; }
+        [CascadingParameter] private ModalOptions GlobalModalOptions { get; set; }
+
+        [Parameter] public ModalOptions Options { get; set; }
+        [Parameter] public string Title { get; set; }
+        [Parameter] public RenderFragment Content { get; set; }
+        [Parameter] public Guid Id { get; set; }
+
+        private string Position { get; set; }
+        private string Class { get; set; }
+        private string AnimationClass { get; set; }
+        private bool HideHeader { get; set; }
+        private bool HideCloseButton { get; set; }
+        private bool DisableBackgroundCancel { get; set; }
+
+        private ElementReference _modalReference;
+
+        protected override void OnInitialized()
+        {
+            ConfigureInstance();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                await JSRuntime.InvokeVoidAsync("BlazoredModal.activateFocusTrap", _modalReference, Id);
+            }
+        }
+
+        /// <summary>
+        /// Sets the title for the modal being displayed
+        /// </summary>
+        /// <param name="title">Text to display as the title of the modal</param>
+        public void SetTitle(string title)
+        {
+            Title = title;
+            StateHasChanged();
+        }
+
+        /// <summary>
+        /// Closes the modal with a default Ok result />.
+        /// </summary>
+        public async Task Close()
+        {
+            await Close(ModalResult.Ok<object>(null));
+        }
+
+        /// <summary>
+        /// Closes the modal with the specified <paramref name="modalResult"/>.
+        /// </summary>
+        /// <param name="modalResult"></param>
+        public async Task Close(ModalResult modalResult)
+        {
+            // Fade out the modal, and after that actually remove it
+            if (Options.Animation?.Type == ModalAnimationType.FadeOut || Options.Animation?.Type == ModalAnimationType.FadeInOut)
+            {
+                AnimationClass = "blazored-modal-fade-out";
+                StateHasChanged();
+                await Task.Delay((int)(Options?.Animation?.Duration * 1000) + 100); // Needs to be a bit more than the animation time because of delays in the animation being applied between server and client (at least when using blazor server side), I think.
+            }
+
+            await Parent.DismissInstance(Id, modalResult);
+        }
+
+        /// <summary>
+        /// Closes the modal and returns a cancelled ModalResult.
+        /// </summary>
+        public async Task Cancel()
+        {
+            await Close(ModalResult.Cancel());
+        }
+
+        private void ConfigureInstance()
+        {
+            Position = SetPosition();
+            Class = SetClass();
+            AnimationClass = SetAnimationClass();
+            HideHeader = SetHideHeader();
+            HideCloseButton = SetHideCloseButton();
+            DisableBackgroundCancel = SetDisableBackgroundCancel();
+        }
+
+        private string SetPosition()
+        {
+            ModalPosition position;
+            if (Options.Position.HasValue)
+            {
+                position = Options.Position.Value;
+            }
+            else if (GlobalModalOptions.Position.HasValue)
+            {
+                position = GlobalModalOptions.Position.Value;
+            }
+            else
+            {
+                position = ModalPosition.Center;
+            }
+
+            switch (position)
+            {
+                case ModalPosition.Center:
+                    return "blazored-modal-center";
+                case ModalPosition.TopLeft:
+                    return "blazored-modal-topleft";
+                case ModalPosition.TopRight:
+                    return "blazored-modal-topright";
+                case ModalPosition.BottomLeft:
+                    return "blazored-modal-bottomleft";
+                case ModalPosition.BottomRight:
+                    return "blazored-modal-bottomright";
+                default:
+                    return "blazored-modal-center";
+            }
+        }
+
+        private async Task HandleWrapperKeyUp(KeyboardEventArgs e)
+        {
+            if (e.Code == "Escape")
+            {
+                await Parent.DismissInstance(Id, ModalResult.Cancel());
+            }
+        }
+
+        private string SetClass()
+        {
+            if (!string.IsNullOrWhiteSpace(Options.Class))
+                return Options.Class;
+
+            if (!string.IsNullOrWhiteSpace(GlobalModalOptions.Class))
+                return GlobalModalOptions.Class;
+
+            return "blazored-modal";
+        }
+
+        private string SetAnimationClass()
+        {
+            switch (Options.Animation?.Type)
+            {
+                case ModalAnimationType.None:
+                    return string.Empty;
+                case ModalAnimationType.FadeIn:
+                case ModalAnimationType.FadeInOut:
+                    return "blazored-modal-fade-in";
+                case ModalAnimationType.FadeOut:
+                    //return "blazored-modal-fade-out";
+                    return string.Empty;
+                    //return "blazored-modal-fade-in-out";
+                    return string.Empty;
+                default:
+                    return string.Empty;
+            }
+        }
+
+        private bool SetHideHeader()
+        {
+            if (Options.HideHeader.HasValue)
+                return Options.HideHeader.Value;
+
+            if (GlobalModalOptions.HideHeader.HasValue)
+                return GlobalModalOptions.HideHeader.Value;
+
+            return false;
+        }
+
+        private bool SetHideCloseButton()
+        {
+            if (Options.HideCloseButton.HasValue)
+                return Options.HideCloseButton.Value;
+
+            if (GlobalModalOptions.HideCloseButton.HasValue)
+                return GlobalModalOptions.HideCloseButton.Value;
+
+            return false;
+        }
+
+        private bool SetDisableBackgroundCancel()
+        {
+            if (Options.DisableBackgroundCancel.HasValue)
+                return Options.DisableBackgroundCancel.Value;
+
+            if (GlobalModalOptions.DisableBackgroundCancel.HasValue)
+                return GlobalModalOptions.DisableBackgroundCancel.Value;
+
+            return false;
+        }
+
+        private async Task HandleBackgroundClick()
+        {
+            if (DisableBackgroundCancel) return;
+
+            await Cancel();
+        }
+    }
+}

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -69,7 +69,10 @@ namespace Blazored.Modal
             {
                 AnimationClass = "blazored-modal-fade-out";
                 StateHasChanged();
-                await Task.Delay((int)(Options?.Animation?.Duration * 1000) + 100); // Needs to be a bit more than the animation time because of delays in the animation being applied between server and client (at least when using blazor server side), I think.
+                if (Options?.Animation?.Duration > 0)
+                {
+                    await Task.Delay((int)(Options?.Animation?.Duration * 1000) + 100); // Needs to be a bit more than the animation time because of delays in the animation being applied between server and client (at least when using blazor server side), I think.
+                }
             }
 
             await Parent.DismissInstance(Id, modalResult);
@@ -147,21 +150,12 @@ namespace Blazored.Modal
 
         private string SetAnimationClass()
         {
-            switch (Options.Animation?.Type)
+            if (Options.Animation?.Type == ModalAnimationType.FadeIn || Options.Animation?.Type == ModalAnimationType.FadeInOut)
             {
-                case ModalAnimationType.None:
-                    return string.Empty;
-                case ModalAnimationType.FadeIn:
-                case ModalAnimationType.FadeInOut:
-                    return "blazored-modal-fade-in";
-                case ModalAnimationType.FadeOut:
-                    //return "blazored-modal-fade-out";
-                    return string.Empty;
-                    //return "blazored-modal-fade-in-out";
-                    return string.Empty;
-                default:
-                    return string.Empty;
+                return "blazored-modal-fade-in";
             }
+
+            return string.Empty;
         }
 
         private bool SetHideHeader()

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -150,7 +150,11 @@ namespace Blazored.Modal
 
         private string SetAnimationClass()
         {
-            if (Options.Animation?.Type == ModalAnimationType.FadeIn || Options.Animation?.Type == ModalAnimationType.FadeInOut)
+            ModalAnimation animation;
+            animation = Options?.Animation ??
+                        GlobalModalOptions?.Animation ?? new ModalAnimation(ModalAnimationType.None, 0);
+
+            if (animation.Type == ModalAnimationType.FadeIn || animation.Type == ModalAnimationType.FadeInOut)
             {
                 return "blazored-modal-fade-in";
             }

--- a/src/Blazored.Modal/ModalAnimation.cs
+++ b/src/Blazored.Modal/ModalAnimation.cs
@@ -6,6 +6,12 @@ namespace Blazored.Modal
 {
     public class ModalAnimation
     {
+        public ModalAnimation(ModalAnimationType type, double duration)
+        {
+            Type = type;
+            Duration = duration;
+        }
+
         public ModalAnimationType Type { get; set; }
 
         public double? Duration { get; set; }

--- a/src/Blazored.Modal/ModalAnimation.cs
+++ b/src/Blazored.Modal/ModalAnimation.cs
@@ -4,7 +4,14 @@ using System.Text;
 
 namespace Blazored.Modal
 {
-    public enum ModalAnimation
+    public class ModalAnimation
+    {
+        public ModalAnimationType Type { get; set; }
+
+        public double? Duration { get; set; }
+    }
+
+    public enum ModalAnimationType
     {
         None = 0, // Set to 0 so it is definitely the default value
         FadeIn,

--- a/src/Blazored.Modal/ModalAnimation.cs
+++ b/src/Blazored.Modal/ModalAnimation.cs
@@ -6,15 +6,18 @@ namespace Blazored.Modal
 {
     public class ModalAnimation
     {
+        public ModalAnimationType Type { get; set; }
+        public double? Duration { get; set; }
+
         public ModalAnimation(ModalAnimationType type, double duration)
         {
             Type = type;
             Duration = duration;
         }
 
-        public ModalAnimationType Type { get; set; }
-
-        public double? Duration { get; set; }
+        public static ModalAnimation FadeIn(double duration) => new ModalAnimation(ModalAnimationType.FadeIn, duration);
+        public static ModalAnimation FadeOut(double duration) => new ModalAnimation(ModalAnimationType.FadeOut, duration);
+        public static ModalAnimation FadeInOut(double duration) => new ModalAnimation(ModalAnimationType.FadeInOut, duration);
     }
 
     public enum ModalAnimationType

--- a/src/Blazored.Modal/ModalAnimation.cs
+++ b/src/Blazored.Modal/ModalAnimation.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazored.Modal
+{
+    public enum ModalAnimation
+    {
+        None = 0, // Set to 0 so it is definitely the default value
+        FadeIn,
+        FadeOut,
+        FadeInOut
+    }
+}

--- a/src/Blazored.Modal/ModalOptions.cs
+++ b/src/Blazored.Modal/ModalOptions.cs
@@ -7,5 +7,7 @@
         public bool? DisableBackgroundCancel { get; set; }
         public bool? HideHeader { get; set; }
         public bool? HideCloseButton { get; set; }
+
+        public ModalAnimation Animation { get; set; }
     }
 }

--- a/src/Blazored.Modal/wwwroot/blazored-modal.css
+++ b/src/Blazored.Modal/wwwroot/blazored-modal.css
@@ -29,6 +29,33 @@
     box-shadow: 0 2px 2px rgba(0,0,0,.25);
 }
 
+.blazored-modal-fade-in {
+    animation: 1s ease-out 0s ModalFadeIn;
+}
+
+.blazored-modal-fade-out {
+    animation: 1s ease-out 0s ModalFadeOut;
+    opacity: 0;
+}
+
+@keyframes ModalFadeIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+@keyframes ModalFadeOut {
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
 .blazored-modal-header {
     display: flex;
     align-items: flex-start;

--- a/src/Blazored.Modal/wwwroot/blazored-modal.css
+++ b/src/Blazored.Modal/wwwroot/blazored-modal.css
@@ -29,33 +29,6 @@
     box-shadow: 0 2px 2px rgba(0,0,0,.25);
 }
 
-.blazored-modal-fade-in {
-    animation: 1s ease-out 0s ModalFadeIn;
-}
-
-.blazored-modal-fade-out {
-    animation: 1s ease-out 0s ModalFadeOut;
-    opacity: 0;
-}
-
-@keyframes ModalFadeIn {
-    0% {
-        opacity: 0;
-    }
-    100% {
-        opacity: 1;
-    }
-}
-
-@keyframes ModalFadeOut {
-    0% {
-        opacity: 1;
-    }
-    100% {
-        opacity: 0;
-    }
-}
-
 .blazored-modal-header {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
This PR adds support for animations to resolve #166. For now I have made 2 settings available: the duration and the type (fade-in, fade-out or fade-in/fade-out). The way it works is that some CSS is generated for each modal instance. It is sort of 'templated' where Blazor will add the correct values like duration to the CSS. It does feel a little hacky but it seems to work very stable. If anyone has any concerns about that, please let me know!

With this approach a lot of different settings could be added rather quickly I think. One thing I thought of is also exposing the Easing mode of the animation, like ease-in and ease-out, via an enum. Before doing that I would like some feedback on this approach and its usefulness first though. 

Global animation settings as well as different animations for multi-modal scenarios are also supported.

Please have a look and see if you like it.