### PR TITLE
Removed ability to dismiss the modal using escape

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -41,7 +41,7 @@ else
 
         <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-        <div id="_@Id.ToString("N")" class="@Class @AnimationClass" @onkeyup="HandleWrapperKeyUp">
+        <div id="_@Id.ToString("N")" class="@Class @AnimationClass">
             @if (!HideHeader)
             {
                 <div class="blazored-modal-header">

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -155,14 +155,6 @@ namespace Blazored.Modal
             }
         }
 
-        private async Task HandleWrapperKeyUp(KeyboardEventArgs e)
-        {
-            if (e.Code == "Escape")
-            {
-                await Parent.DismissInstance(Id, ModalResult.Cancel());
-            }
-        }
-
         private string SetClass()
         {
             if (!string.IsNullOrWhiteSpace(Options.Class))


### PR DESCRIPTION
It turns out the `@onkeyup` event on the modal was causing various form components to behave oddly. I couldn't track the exact cause but removing this handler fixes the issue. The trade-off is that it removed the ability to dismiss the modal using the escape key. I'm not sure it's the end of the world though as pressing the escape key is a valid operation when inside Blazored Typeahead and if using it inside Modal, this would have dismissed the modal not just the suggestion list. 

Resolves #201 