### PR TITLE
Renamed BlazoredModalInstance Close and Cancel methods with Async suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you want to pass values to the component you're displaying in the modal, then
     </div>
 
     <button @onclick="SaveMovie" class="btn btn-primary">Submit</button>
-    <button @onclick="BlazoredModal.Cancel" class="btn btn-secondary">Cancel</button>
+    <button @onclick="BlazoredModal.CancelAsync" class="btn btn-secondary">Cancel</button>
 </div>
 
 @code {
@@ -270,9 +270,9 @@ In the example below, when the form is submitted a `ModalResult.Ok` containing t
         await BlazoredModal.CloseAsync(ModalResult.Ok($"Form was submitted successfully."));
     }
 
-    void Cancel()
+    async Task Cancel()
     {
-        BlazoredModal.Cancel();
+        await BlazoredModal.CancelAsync();
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ If you want to pass values to the component you're displaying in the modal, then
         Movie = MovieService.Load(MovieId);
     }
 
-    void SaveMovie()
+    async Task SaveMovie()
     {
         MovieService.Save(Movie);
-        BlazoredModal.Close(ModalResult.Ok<Movie>(Movie));
+        await BlazoredModal.CloseAsync(ModalResult.Ok<Movie>(Movie));
     }
 
 }
@@ -265,9 +265,9 @@ In the example below, when the form is submitted a `ModalResult.Ok` containing t
     string LastName { get; set; }
     int FormId { get; set; }
 
-    void SubmitForm()
+    async Task SubmitForm()
     {
-        BlazoredModal.Close(ModalResult.Ok($"Form was submitted successfully."));
+        await BlazoredModal.CloseAsync(ModalResult.Ok($"Form was submitted successfully."));
     }
 
     void Cancel()
@@ -477,12 +477,12 @@ Below is a component which being displayed inside a Blazored Modal instance. Whe
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close(ModalResult.Ok($"The user said 'Yes'"));
+        await BlazoredModal.CloseAsync(ModalResult.Ok($"The user said 'Yes'"));
     }
 
     void No()
     {
-        BlazoredModal.Close(ModalResult.Cancel());
+        await BlazoredModal.CloseAsync(ModalResult.Cancel());
     }
 
 }

--- a/samples/BlazorServer/Shared/Confirm.razor
+++ b/samples/BlazorServer/Shared/Confirm.razor
@@ -9,7 +9,7 @@
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
-    void Close() => BlazoredModal.Close(ModalResult.Ok(true));
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
     void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorServer/Shared/Confirm.razor
+++ b/samples/BlazorServer/Shared/Confirm.razor
@@ -10,6 +10,6 @@
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
     async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorServer/Shared/CustomBootstrapModal.razor
@@ -22,7 +22,7 @@
 
     [Parameter] public string Message { get; set; }
 
-    async Task Close() => await BlazoredModal.Close(ModalResult.Ok(true));
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
     async Task Cancel() => await BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorServer/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorServer/Shared/CustomBootstrapModal.razor
@@ -23,6 +23,6 @@
     [Parameter] public string Message { get; set; }
 
     async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
-    async Task Cancel() => await BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/DisplayMessage.razor
+++ b/samples/BlazorServer/Shared/DisplayMessage.razor
@@ -12,7 +12,7 @@
 
     [Parameter] public string Message { get; set; }
 
-    void SubmitForm() => BlazoredModal.Close();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync();
     void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorServer/Shared/DisplayMessage.razor
+++ b/samples/BlazorServer/Shared/DisplayMessage.razor
@@ -13,6 +13,6 @@
     [Parameter] public string Message { get; set; }
 
     async Task SubmitForm() => await BlazoredModal.CloseAsync();
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/MessageForm.razor
+++ b/samples/BlazorServer/Shared/MessageForm.razor
@@ -17,7 +17,7 @@
 
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
     
-    void SubmitForm() => BlazoredModal.Close(ModalResult.Ok(Message));
+    async Task SubmitForm() => await BlazoredModal.CloseAsync(ModalResult.Ok(Message));
     void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorServer/Shared/MessageForm.razor
+++ b/samples/BlazorServer/Shared/MessageForm.razor
@@ -18,6 +18,6 @@
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
     
     async Task SubmitForm() => await BlazoredModal.CloseAsync(ModalResult.Ok(Message));
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/YesNoPrompt.razor
+++ b/samples/BlazorServer/Shared/YesNoPrompt.razor
@@ -22,6 +22,6 @@
         await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/YesNoPrompt.razor
+++ b/samples/BlazorServer/Shared/YesNoPrompt.razor
@@ -19,7 +19,7 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
     void No() => BlazoredModal.Cancel();

--- a/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
@@ -24,6 +24,6 @@
         await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
@@ -21,7 +21,7 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
     void No() => BlazoredModal.Cancel();

--- a/samples/BlazorWebAssembly/Shared/Confirm.razor
+++ b/samples/BlazorWebAssembly/Shared/Confirm.razor
@@ -9,7 +9,7 @@
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
-    void Close() => BlazoredModal.Close(ModalResult.Ok(true));
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
     void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorWebAssembly/Shared/Confirm.razor
+++ b/samples/BlazorWebAssembly/Shared/Confirm.razor
@@ -10,6 +10,6 @@
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
     async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorWebAssembly/Shared/CustomBootstrapModal.razor
@@ -23,6 +23,6 @@
     [Parameter] public string Message { get; set; }
 
     async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorWebAssembly/Shared/CustomBootstrapModal.razor
@@ -22,7 +22,7 @@
 
     [Parameter] public string Message { get; set; }
 
-    void Close() => BlazoredModal.Close(ModalResult.Ok(true));
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
     void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
+++ b/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
@@ -12,7 +12,7 @@
     
     [Parameter] public string Message { get; set; }
 
-    void SubmitForm() => BlazoredModal.Close();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync();
     void Cancel() => BlazoredModal.Cancel();
 
 }

--- a/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
+++ b/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
@@ -13,6 +13,6 @@
     [Parameter] public string Message { get; set; }
 
     async Task SubmitForm() => await BlazoredModal.CloseAsync();
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/MessageForm.razor
+++ b/samples/BlazorWebAssembly/Shared/MessageForm.razor
@@ -22,7 +22,7 @@
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
 
     async Task SubmitForm() => await BlazoredModal.CloseAsync(ModalResult.Ok(_form.Message));
-    async Task Cancel() => await BlazoredModal.Cancel();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
     public class Form
     {

--- a/samples/BlazorWebAssembly/Shared/MessageForm.razor
+++ b/samples/BlazorWebAssembly/Shared/MessageForm.razor
@@ -21,7 +21,7 @@
 
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
 
-    async Task SubmitForm() => await BlazoredModal.Close(ModalResult.Ok(_form.Message));
+    async Task SubmitForm() => await BlazoredModal.CloseAsync(ModalResult.Ok(_form.Message));
     async Task Cancel() => await BlazoredModal.Cancel();
 
     public class Form

--- a/samples/BlazorWebAssembly/Shared/YesNoPrompt.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPrompt.razor
@@ -22,6 +22,6 @@
         await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/YesNoPrompt.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPrompt.razor
@@ -19,7 +19,7 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
     void No() => BlazoredModal.Cancel();

--- a/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
@@ -21,7 +21,7 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
     void No() => BlazoredModal.Cancel();

--- a/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
@@ -24,6 +24,6 @@
         await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -57,16 +57,16 @@ namespace Blazored.Modal
         /// <summary>
         /// Closes the modal with a default Ok result />.
         /// </summary>
-        public async Task Close()
+        public async Task CloseAsync()
         {
-            await Close(ModalResult.Ok<object>(null));
+            await CloseAsync(ModalResult.Ok<object>(null));
         }
 
         /// <summary>
         /// Closes the modal with the specified <paramref name="modalResult"/>.
         /// </summary>
         /// <param name="modalResult"></param>
-        public async Task Close(ModalResult modalResult)
+        public async Task CloseAsync(ModalResult modalResult)
         {
             // Fade out the modal, and after that actually remove it
             if (Options.Animation?.Type == ModalAnimationType.FadeOut || Options.Animation?.Type == ModalAnimationType.FadeInOut)
@@ -87,7 +87,7 @@ namespace Blazored.Modal
         /// </summary>
         public async Task Cancel()
         {
-            await Close(ModalResult.Cancel());
+            await CloseAsync(ModalResult.Cancel());
         }
 
         private void ConfigureInstance()

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -85,7 +85,7 @@ namespace Blazored.Modal
         /// <summary>
         /// Closes the modal and returns a cancelled ModalResult.
         /// </summary>
-        public async Task Cancel()
+        public async Task CancelAsync()
         {
             await CloseAsync(ModalResult.Cancel());
         }
@@ -217,7 +217,7 @@ namespace Blazored.Modal
         {
             if (DisableBackgroundCancel) return;
 
-            await Cancel();
+            await CancelAsync();
         }
     }
 }

--- a/tests/src/Blazored.Modal.Tests/Assets/TestComponent.razor
+++ b/tests/src/Blazored.Modal.Tests/Assets/TestComponent.razor
@@ -1,6 +1,6 @@
 ﻿<div class="test-component">
     <h1>@Title</h1>
-    <button class="test-component__close-button" @onclick="BlazoredModal.Close">Close</button>
+    <button class="test-component__close-button" @onclick="BlazoredModal.CloseAsync">Close</button>
 </div>
 
 @code {


### PR DESCRIPTION
Renamed the Close method to CloseAsync and updated all sample components using it with the README. While at it, I applied the same change to the Cancel method.