### PR TITLE
Focus traps are now deactivated when navigating from page

### DIFF
--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -80,6 +80,7 @@ namespace Blazored.Modal
         {
             foreach (var modalReference in Modals)
             {
+                await JSRuntime.InvokeVoidAsync("BlazoredModal.deactivateFocusTrap", modalReference.Id);
                 modalReference.Dismiss(ModalResult.Cancel());
             }
 


### PR DESCRIPTION
Resolves #212

When navigating from a page when a modal window is open, the focus trap prevents user from interacting with the page.

By invoking the deactivateFocusTrap method, the web now works as intended.