### PR TITLE
 Added allowOutsideClick to capture clicks outside the focus trap

### DIFF
--- a/src/Blazored.Modal/Interop/Blazored.Modal.ts
+++ b/src/Blazored.Modal/Interop/Blazored.Modal.ts
@@ -6,8 +6,8 @@ interface FocusTrapInstance {
 }
 
 export class BlazoredModal {
-
-    readonly _options: Options = { escapeDeactivates: false };
+    
+    readonly _options: Options = { escapeDeactivates: false, allowOutsideClick: () => true };
     private _traps: Array<FocusTrapInstance> = [];
 
     public activateScrollLock(): void {


### PR DESCRIPTION
This is commit, adds `allowOutsideClick: () => true` in to Blazored.Modal.ts which should fix #224  (and fix #217 and fix #236).

The reason I've used a function that returns true `:() => true` instead of just setting it `:true`, is that Blazored.Modal is not using the latest version of "focus-trap" library. 

`allowOutsideClick` property in Blazored-Modal currently:
```
    allowOutsideClick?: (event: MouseEvent) => boolean;
```

`allowOutsideClick` property in current version of focus-trap library:
```
    allowOutsideClick?: boolean | MouseEventToBoolean;
```

Updating focus-trap should solve this, but this works for now.