### PR TITLE
Gracefully close modal when close is called

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -48,7 +48,7 @@ else
                     <h3 class="blazored-modal-title">@Title</h3>
                     @if (!HideCloseButton)
                     {
-                        <button type="button" class="blazored-modal-close" tabindex="-1" @onclick="(() => Parent.CancelInstance(Id))">
+                        <button type="button" class="blazored-modal-close" tabindex="-1" @onclick="Cancel">
                             <span>&times;</span>
                         </button>
                     }

--- a/src/Blazored.Modal/Configuration/ModalReference.cs
+++ b/src/Blazored.Modal/Configuration/ModalReference.cs
@@ -36,6 +36,7 @@ namespace Blazored.Modal
 
         internal Guid Id { get; }
         internal RenderFragment ModalInstance { get; }
+        internal BlazoredModalInstance ModalInstanceRef { get; set; }
 
         public Task<ModalResult> Result => _resultCompletion.Task;
 

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -115,6 +115,7 @@ namespace Blazored.Modal.Services
             }
 
             var modalInstanceId = Guid.NewGuid();
+            ModalReference modalReference = null;
             var modalContent = new RenderFragment(builder =>
             {
                 var i = 0;
@@ -132,9 +133,10 @@ namespace Blazored.Modal.Services
                 builder.AddAttribute(2, "Title", title);
                 builder.AddAttribute(3, "Content", modalContent);
                 builder.AddAttribute(4, "Id", modalInstanceId);
+                builder.AddComponentReferenceCapture(5, compRef => modalReference.ModalInstanceRef = (BlazoredModalInstance)compRef);
                 builder.CloseComponent();
             });
-            var modalReference = new ModalReference(modalInstanceId, modalInstance, this);
+            modalReference = new ModalReference(modalInstanceId, modalInstance, this);
 
             OnModalInstanceAdded?.Invoke(modalReference);
 

--- a/tests/src/Blazored.Modal.Tests/DisplayTests.cs
+++ b/tests/src/Blazored.Modal.Tests/DisplayTests.cs
@@ -94,5 +94,22 @@ namespace Blazored.Modal.Tests
             // Assert
             Assert.Empty(cut.FindAll(".blazored-modal-container"));
         }
+
+        [Fact]
+        public void ModalHidesWhenReferenceCloseCalled()
+        {
+            // Arrange
+            var modalService = Services.GetService<IModalService>();
+            var cut = RenderComponent<BlazoredModal>(CascadingValue(modalService));
+
+            // Act
+            var modalReferece = modalService.Show<TestComponent>();
+            Assert.Equal(1, cut.FindAll(".blazored-modal-container").Count);
+
+            modalReferece.Close();
+
+            // Assert
+            Assert.Empty(cut.FindAll(".blazored-modal-container"));
+        }
     }
 }


### PR DESCRIPTION
This changes the behavior of the `BlazoredModal` `.CloseInstance` and `.CancelInstance` methods to "gracefully" close the modal by calling the `BlazoredModalInstance.Close` method instead if just dismissing it.
This allows the configured animations (and future features) to also work when a close is requested programmatically from the returned `ModalReference`.

To achieve this a reference to the displayed `BlazoredModalInstance` had to be captured, and is stored internally in `ModalReference`.
