### PR TITLE
[Bugfix] Navigate Away

### DIFF
--- a/samples/BlazorWebAssembly/Pages/NavigateAfterModal.razor
+++ b/samples/BlazorWebAssembly/Pages/NavigateAfterModal.razor
@@ -1,0 +1,40 @@
+﻿@page "/navigateAway"
+
+<h1>Navigate away</h1>
+
+<hr class="mb-5" />
+
+@inject NavigationManager Navigator
+
+<p>
+    This is an example of using Blazored Modal and navigating to a different page afterwards
+</p>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("Modal.Show<Confirm>(\"Welcome to Blazored Modal\", options);")
+            </code>
+        </p>
+    </div>
+</div>
+
+<button @onclick="ShowModal" class="btn btn-primary">Show Modal</button>
+
+@code {
+
+    [CascadingParameter] public IModalService Modal { get; set; }
+
+    async void ShowModal()
+    {
+        var modal = Modal.Show<Confirm>("Do you want to navigate to a different page?");
+        var result = await modal.Result;
+
+        if (!result.Cancelled && (result.Data is bool accepted) && accepted)
+        {
+            Navigator.NavigateTo ("/");
+        }
+    }
+
+}

--- a/samples/BlazorWebAssembly/Shared/NavMenu.razor
+++ b/samples/BlazorWebAssembly/Shared/NavMenu.razor
@@ -44,6 +44,9 @@
             <NavLink class="nav-link" href="scrollablecontent" Match="NavLinkMatch.All">
                 <span class="oi oi-resize-height" aria-hidden="true"></span> Scrollable Content
             </NavLink>
+            <NavLink class="nav-link" href="navigateAway" Match="NavLinkMatch.All">
+                <span class="oi oi-external-link" aria-hidden="true"></span> Navigate away
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -78,7 +78,7 @@ namespace Blazored.Modal
 
         private async void CancelModals(object sender, LocationChangedEventArgs e)
         {
-            foreach (var modalReference in Modals)
+            foreach (var modalReference in Modals.ToList())
             {
                 await JSRuntime.InvokeVoidAsync("BlazoredModal.deactivateFocusTrap", modalReference.Id);
                 modalReference.Dismiss(ModalResult.Cancel());


### PR DESCRIPTION
This should fix #230. It does so by calling `.ToList()` on the list in `CancelModals` and looping over that. This way, if the underlying collection changes during the loop, it won't cause an exception here.

I am not sure this is the best solution. If the underlying collection changes while looping over it, maybe we should catch this using `try { ... } catch() { ... } and loop again over the changed collection so that all items in the collection are removed, even when one is added midway trough removing them. I made this PR just so we can look at a possible solution, but I am not convinced yet this is really the best solution. Would love to hear what your opinions are on this.