### PR TITLE
[Bugfix] Fixes representation of animation duration when the current culture doesn't use a period as the decimal separator

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -6,13 +6,13 @@
 }
 else
 {
-    <style>
+<style>
     #_@(Id.ToString("N")).blazored-modal-fade-in {
-        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation?.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeIn;
+        animation: @AnimationDuration ease-out 0s ModalFadeIn;
     }
 
     #_@(Id.ToString("N")).blazored-modal-fade-out {
-        animation: @((Options?.Animation?.Duration ?? GlobalModalOptions?.Animation?.Duration ?? 0) * 1000)ms ease-out 0s ModalFadeOut;
+        animation: @AnimationDuration ease-out 0s ModalFadeOut;
         opacity: 0;
     }
 
@@ -35,7 +35,7 @@ else
             opacity: 0;
         }
     }
-    </style>
+</style>
 
     <div class="blazored-modal-container @Position" @ref="_modalReference">
 

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -25,6 +25,13 @@ namespace Blazored.Modal
         private bool HideCloseButton { get; set; }
         private bool DisableBackgroundCancel { get; set; }
 
+		private string AnimationDuration {
+            get {
+                var duration = (Options?.Animation?.Duration ?? GlobalModalOptions?.Animation?.Duration ?? 0) * 1000;
+                return FormattableString.Invariant($"{duration}ms");
+            }
+        }
+
         public bool UseCustomLayout { get; set; }
 
         [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "This is assigned in Razor code and isn't currently picked up by the tooling.")]


### PR DESCRIPTION
Fixes #235 