### PR TITLE
Add basic ARIA attributes to modal

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -41,14 +41,14 @@ else
 
         <div class="blazored-modal-overlay" @onclick="HandleBackgroundClick"></div>
 
-        <div id="_@Id.ToString("N")" class="@Class">
+        <div id="_@Id.ToString("N")" class="@Class" role="dialog" aria-modal="true" >
             @if (!HideHeader)
             {
                 <div class="blazored-modal-header">
                     <h3 class="blazored-modal-title">@Title</h3>
                     @if (!HideCloseButton)
                     {
-                        <button type="button" class="blazored-modal-close" tabindex="-1" @onclick="Cancel">
+                        <button type="button" class="blazored-modal-close" aria-label="close" @onclick="Cancel">
                             <span>&times;</span>
                         </button>
                     }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -48,7 +48,7 @@ else
                     <h3 class="blazored-modal-title">@Title</h3>
                     @if (!HideCloseButton)
                     {
-                        <button type="button" class="blazored-modal-close" aria-label="close" @onclick="Cancel">
+                        <button type="button" class="blazored-modal-close" aria-label="close" @onclick="Cancel" @attributes="@_closeBtnAttributes"> 
                             <span>&times;</span>
                         </button>
                     }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Blazored.Modal.Services;
 using Microsoft.AspNetCore.Components;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
@@ -37,6 +38,9 @@ namespace Blazored.Modal
         [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "This is assigned in Razor code and isn't currently picked up by the tooling.")]
         private ElementReference _modalReference;
 
+        // Temporarily add a tabindex of -1 to the close button so it doesn't get selected as the first element by activateFocusTrap
+        private readonly Dictionary<string, object> _closeBtnAttributes = new Dictionary<string, object> { { "tabindex", "-1" } };
+
         protected override void OnInitialized()
         {
             ConfigureInstance();
@@ -47,6 +51,8 @@ namespace Blazored.Modal
             if (firstRender)
             {
                 await JSRuntime.InvokeVoidAsync("BlazoredModal.activateFocusTrap", _modalReference, Id);
+                _closeBtnAttributes.Clear();
+                StateHasChanged();
             }
         }
 


### PR DESCRIPTION
This PR fixes #211 by implementing the correct `aria-label` for the close button, allowing the user to tab to the close button, and adding the correct role to the Modal itself.

Re-enabling the tabindex on the close button caused the FocusTrap to autofocus the close button each time the modal was opened. I really didn't like this behavior, and have implemented a fix for this by applying setting the tabindex to -1 at first, and only removing it after the FocusTrap is activated. This way the close button is not autofocused, but it is focusable.