### PR TITLE
Link to Nuget and Build Status in readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 A powerful and customizable modal implementation for [Blazor](https://blazor.net) applications.
 
-![Build Status](https://github.com/Blazored/Modal/workflows/Build%20&%20Test%20Main/badge.svg)
-
-![Nuget](https://img.shields.io/nuget/v/blazored.modal.svg)
+[![Build Status](https://github.com/Blazored/Modal/workflows/Build%20&%20Test%20Main/badge.svg)](https://github.com/Blazored/Modal/actions?query=workflow%3A%22Build+%26+Test+Main%22)
+[![Nuget](https://img.shields.io/nuget/v/blazored.modal.svg)](https://www.nuget.org/packages/Blazored.Modal/)
 
 ![Screenshot of the component in action](screenshot.png)
 


### PR DESCRIPTION
Currently links directly to the images