### PR TITLE
Able to optionally set focus to first element to false

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -26,8 +26,10 @@ namespace Blazored.Modal
         private bool HideCloseButton { get; set; }
         private bool DisableBackgroundCancel { get; set; }
 
-		private string AnimationDuration {
-            get {
+        private string AnimationDuration
+        {
+            get
+            {
                 var duration = (Options?.Animation?.Duration ?? GlobalModalOptions?.Animation?.Duration ?? 0) * 1000;
                 return FormattableString.Invariant($"{duration}ms");
             }
@@ -50,7 +52,8 @@ namespace Blazored.Modal
         {
             if (firstRender)
             {
-                await JSRuntime.InvokeVoidAsync("BlazoredModal.activateFocusTrap", _modalReference, Id);
+                if (Options?.FocusFirstElement ?? true)
+                    await JSRuntime.InvokeVoidAsync("BlazoredModal.activateFocusTrap", _modalReference, Id);
                 _closeBtnAttributes.Clear();
                 StateHasChanged();
             }
@@ -149,18 +152,24 @@ namespace Blazored.Modal
             {
                 case ModalPosition.Center:
                     return "blazored-modal-center";
+
                 case ModalPosition.TopLeft:
                     return "blazored-modal-topleft";
+
                 case ModalPosition.TopRight:
                     return "blazored-modal-topright";
+
                 case ModalPosition.BottomLeft:
                     return "blazored-modal-bottomleft";
+
                 case ModalPosition.BottomRight:
                     return "blazored-modal-bottomright";
+
                 case ModalPosition.Custom:
                     if (string.IsNullOrWhiteSpace(Options.PositionCustomClass))
                         throw new InvalidOperationException("Position set to Custom without a PositionCustomClass set.");
                     return Options.PositionCustomClass;
+
                 default:
                     return "blazored-modal-center";
             }

--- a/src/Blazored.Modal/Configuration/ModalOptions.cs
+++ b/src/Blazored.Modal/Configuration/ModalOptions.cs
@@ -11,5 +11,6 @@
         public ModalAnimation Animation { get; set; }
         public bool? UseCustomLayout { get; set; }
         public bool? ContentScrollable { get; set; }
+        public bool? FocusFirstElement { get; set; }
     }
 }


### PR DESCRIPTION
Hello,
I am a user of your library. I had a use case, where I needed to disable the auto focus to the first element. 
I figure not everyone would like that to happen. Added boolean FocusFirstElement to the options. Left auto focus as default.

Keep up the good work Chris!