### PR TITLE
#206 | Renamed BlazoredModalInstance Close and Cancel to CloseAsync and CancelAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If you want to pass values to the component you're displaying in the modal, then
     void SaveMovie()
     {
         MovieService.Save(Movie);
-        BlazoredModal.Close(ModalResult.Ok<Movie>(Movie));
+        BlazoredModal.CloseAsync(ModalResult.Ok<Movie>(Movie));
     }
 
 }
@@ -266,12 +266,12 @@ In the example below, when the form is submitted a `ModalResult.Ok` containing t
 
     void SubmitForm()
     {
-        BlazoredModal.Close(ModalResult.Ok($"Form was submitted successfully."));
+        BlazoredModal.CloseAsync(ModalResult.Ok($"Form was submitted successfully."));
     }
 
     void Cancel()
     {
-        BlazoredModal.Cancel();
+        BlazoredModal.CancelAsync();
     }
 
 }
@@ -476,12 +476,12 @@ Below is a component which being displayed inside a Blazored Modal instance. Whe
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close(ModalResult.Ok($"The user said 'Yes'"));
+        BlazoredModal.CloseAsync(ModalResult.Ok($"The user said 'Yes'"));
     }
 
     void No()
     {
-        BlazoredModal.Close(ModalResult.Cancel());
+        BlazoredModal.CloseAsync(ModalResult.Cancel());
     }
 
 }

--- a/samples/BlazorServer/Shared/Confirm.razor
+++ b/samples/BlazorServer/Shared/Confirm.razor
@@ -9,7 +9,7 @@
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
-    void Close() => BlazoredModal.Close(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
+    async Task Cancel() =>await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorServer/Shared/CustomBootstrapModal.razor
@@ -24,7 +24,7 @@
 
     [Parameter] public string Message { get; set; }
 
-    async Task Close() => await BlazoredModal.Close(ModalResult.Ok(true));
-    async Task Cancel() => await BlazoredModal.Cancel();
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/DisplayMessage.razor
+++ b/samples/BlazorServer/Shared/DisplayMessage.razor
@@ -12,7 +12,7 @@
 
     [Parameter] public string Message { get; set; }
 
-    void SubmitForm() => BlazoredModal.Close();
-    void Cancel() => BlazoredModal.Cancel();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/FullContentPage.razor
+++ b/samples/BlazorServer/Shared/FullContentPage.razor
@@ -37,10 +37,10 @@
 @code {
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
-    
+
     [Parameter] public string Message { get; set; }
 
-    void SubmitForm() => BlazoredModal.Close();
-    void Cancel() => BlazoredModal.Cancel();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/MessageForm.razor
+++ b/samples/BlazorServer/Shared/MessageForm.razor
@@ -16,8 +16,8 @@
     string Message { get; set; }
 
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
-    
-    void SubmitForm() => BlazoredModal.Close(ModalResult.Ok(Message));
-    void Cancel() => BlazoredModal.Cancel();
+
+    async Task SubmitForm() => await BlazoredModal.CloseAsync(ModalResult.Ok(Message));
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/YesNoPrompt.razor
+++ b/samples/BlazorServer/Shared/YesNoPrompt.razor
@@ -19,9 +19,9 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorServer/Shared/YesNoPromptAnimation.razor
@@ -21,9 +21,9 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/Confirm.razor
+++ b/samples/BlazorWebAssembly/Shared/Confirm.razor
@@ -9,7 +9,7 @@
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
 
-    void Close() => BlazoredModal.Close(ModalResult.Ok(true));
-    void Cancel() => BlazoredModal.Cancel();
+    async Task Close() =>  await BlazoredModal.CloseAsync(ModalResult.Ok(true));
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorWebAssembly/Shared/CustomBootstrapModal.razor
@@ -24,7 +24,7 @@
 
     [Parameter] public string Message { get; set; }
 
-    async Task Close() => await BlazoredModal.Close(ModalResult.Ok(true));
-    async Task Cancel() => await BlazoredModal.Cancel();
+    async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
+++ b/samples/BlazorWebAssembly/Shared/DisplayMessage.razor
@@ -9,10 +9,10 @@
 @code {
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
-    
+
     [Parameter] public string Message { get; set; }
 
-    void SubmitForm() => BlazoredModal.Close();
-    void Cancel() => BlazoredModal.Cancel();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/FullContentPage.razor
+++ b/samples/BlazorWebAssembly/Shared/FullContentPage.razor
@@ -37,10 +37,10 @@
 @code {
 
     [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
-    
+
     [Parameter] public string Message { get; set; }
 
-    void SubmitForm() => BlazoredModal.Close();
-    void Cancel() => BlazoredModal.Cancel();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync();
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/MessageForm.razor
+++ b/samples/BlazorWebAssembly/Shared/MessageForm.razor
@@ -21,8 +21,8 @@
 
     protected override void OnInitialized() => BlazoredModal.SetTitle("Enter a Message");
 
-    async Task SubmitForm() => await BlazoredModal.Close(ModalResult.Ok(_form.Message));
-    async Task Cancel() => await BlazoredModal.Cancel();
+    async Task SubmitForm() => await BlazoredModal.CloseAsync(ModalResult.Ok(_form.Message));
+    async Task Cancel() => await BlazoredModal.CancelAsync();
 
     public class Form
     {

--- a/samples/BlazorWebAssembly/Shared/YesNoPrompt.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPrompt.razor
@@ -19,9 +19,9 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
+++ b/samples/BlazorWebAssembly/Shared/YesNoPromptAnimation.razor
@@ -21,9 +21,9 @@
         if (result.Cancelled)
             return;
 
-        BlazoredModal.Close();
+        await BlazoredModal.CloseAsync();
     }
 
-    void No() => BlazoredModal.Cancel();
+    async Task No() => await BlazoredModal.CancelAsync();
 
 }

--- a/src/Blazored.Modal/BlazoredModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredModal.razor.cs
@@ -55,7 +55,7 @@ namespace Blazored.Modal
             if (modal.ModalInstanceRef != null)
             {
                 // Gracefully close the modal
-                await modal.ModalInstanceRef.Close(result);
+                await modal.ModalInstanceRef.CloseAsync(result);
             }
             else
             {

--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -48,7 +48,7 @@ else
                     <h3 class="blazored-modal-title">@Title</h3>
                     @if (!HideCloseButton)
                     {
-                        <button type="button" class="blazored-modal-close" aria-label="close" @onclick="Cancel" @attributes="@_closeBtnAttributes"> 
+                        <button type="button" class="blazored-modal-close" aria-label="close" @onclick="CancelAsync" @attributes="@_closeBtnAttributes"> 
                             <span>&times;</span>
                         </button>
                     }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -72,16 +72,16 @@ namespace Blazored.Modal
         /// <summary>
         /// Closes the modal with a default Ok result />.
         /// </summary>
-        public async Task Close()
+        public async Task CloseAsync()
         {
-            await Close(ModalResult.Ok<object>(null));
+            await CloseAsync(ModalResult.Ok<object>(null));
         }
 
         /// <summary>
         /// Closes the modal with the specified <paramref name="modalResult"/>.
         /// </summary>
         /// <param name="modalResult"></param>
-        public async Task Close(ModalResult modalResult)
+        public async Task CloseAsync(ModalResult modalResult)
         {
             // Fade out the modal, and after that actually remove it
             if (Options.Animation?.Type == ModalAnimationType.FadeOut || Options.Animation?.Type == ModalAnimationType.FadeInOut)
@@ -100,9 +100,9 @@ namespace Blazored.Modal
         /// <summary>
         /// Closes the modal and returns a cancelled ModalResult.
         /// </summary>
-        public async Task Cancel()
+        public async Task CancelAsync()
         {
-            await Close(ModalResult.Cancel());
+            await CloseAsync(ModalResult.Cancel());
         }
 
         private void ConfigureInstance()
@@ -272,7 +272,7 @@ namespace Blazored.Modal
         {
             if (DisableBackgroundCancel) return;
 
-            await Cancel();
+            await CancelAsync();
         }
     }
 }

--- a/tests/src/Blazored.Modal.Tests/Assets/TestComponent.razor
+++ b/tests/src/Blazored.Modal.Tests/Assets/TestComponent.razor
@@ -1,6 +1,6 @@
 ﻿<div class="test-component">
     <h1>@Title</h1>
-    <button class="test-component__close-button" @onclick="BlazoredModal.Close">Close</button>
+    <button class="test-component__close-button" @onclick="BlazoredModal.CloseAsync">Close</button>
 </div>
 
 @code {


### PR DESCRIPTION
Hello,
Submiting this PR since, the **PR**:
#207  --> "Renamed BlazoredModalInstance Close and Cancel methods with Async suffix #207"
seems to have gone stale and I already had this sitting on my forked repo.