### PR TITLE
[bugfix] Bootstrap custom modal background clicks

### DIFF
--- a/samples/BlazorServer/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorServer/Shared/CustomBootstrapModal.razor
@@ -1,21 +1,21 @@
-﻿<div class="modal-backdrop fade show"></div>
-<div class="modal fade show d-block" tabindex="-1" role="dialog" @onclick="Cancel">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Modal title</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <p>@Message</p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal" @onclick="Close">Close</button>
-      </div>
+﻿<div class="modal fade show d-block" tabindex="-1" role="dialog">
+    <div class="modal-backdrop fade show" @onclick="Cancel"></div>
+    <div class="modal-dialog" style="z-index: 1050"> <!-- Pop it above the backdrop -->
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Modal title</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>@Message</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal" @onclick="Close">Close</button>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 
 @code {

--- a/samples/BlazorServer/Shared/CustomBootstrapModal.razor
+++ b/samples/BlazorServer/Shared/CustomBootstrapModal.razor
@@ -4,7 +4,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">Modal title</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <button type="button" class="close" aria-label="Close" @onclick="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
@@ -12,7 +12,7 @@
                 <p>@Message</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal" @onclick="Close">Close</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This pr closes #266. It does so by moving the backdrop into the modal (so the click event is properly registered to the backdrop but NOT to the modal itself). It also hooks up the close button in the header of the modal.