### PR TITLE
Change generated javascript to enable IE11 usage again

### DIFF
--- a/src/Blazored.Modal/tsconfig.json
+++ b/src/Blazored.Modal/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES5",
     "module": "commonjs",
     "lib": [ "DOM", "ES2019" ],
     "sourceMap": true,


### PR DESCRIPTION
This pr fixes #228 by changing the generated javascript from ES2019 to ES5. This shouldn't break any existing behavior, and the quick check I did in chrome confirms it doesn't (or atleast, all samples still work).