### PR TITLE
Generic ModalParameters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A powerful and customizable modal implementation for [Blazor](https://blazor.net
 
 ## Getting Setup
 
-You can install the package via the nuget package manager just search for *Blazored.Modal*. You can also install via powershell using the following command.
+You can install the package via the nuget package manager just search for _Blazored.Modal_. You can also install via powershell using the following command.
 
 ```powershell
 Install-Package Blazored.Modal
@@ -22,6 +22,7 @@ dotnet add package Blazored.Modal
 ```
 
 #### Internet Explorer 11
+
 This package can be used with Internet Explorer 11, but some special care should to be taken.
 
 - Only Blazor Server works with IE11. Blazor WebAssembly does not work with any IE version. See [this](https://docs.microsoft.com/en-us/aspnet/core/blazor/supported-platforms?view=aspnetcore-3.1)
@@ -63,7 +64,7 @@ public static async Task Main(string[] args)
 
 ### 2. Add Imports
 
-Add the following to your *_Imports.razor*
+Add the following to your _\_Imports.razor_
 
 ```razor
 @using Blazored.Modal
@@ -72,7 +73,7 @@ Add the following to your *_Imports.razor*
 
 ### 3. Add CascadingBlazoredModal Component around the existing Router component
 
-Add the `<CascadingBlazoredModal />` component into your applications *App.razor*, wrapping the Router as per the example below.
+Add the `<CascadingBlazoredModal />` component into your applications _App.razor_, wrapping the Router as per the example below.
 
 ```razor
 <CascadingBlazoredModal>
@@ -97,7 +98,8 @@ Then add a reference to the Blazored Modal JavaScript file at the bottom of the 
 ```
 
 ## Usage
-Please checkout the [sample projects](https://github.com/Blazored/Modal/tree/main/samples) in this repo to see working examples of the features in the modal. 
+
+Please checkout the [sample projects](https://github.com/Blazored/Modal/tree/main/samples) in this repo to see working examples of the features in the modal.
 
 ### Displaying the modal
 
@@ -149,6 +151,39 @@ If you want to pass values to the component you're displaying in the modal, then
         parameters.Add(nameof(EditMovie.MovieId), movieId);
 
         Modal.Show<EditMovie>("Edit Movie", parameters);
+    }
+
+}
+```
+
+#### Index Component (Generic ModalParameters)
+
+```razor
+@page "/"
+
+<h1>My Movies</h1>
+
+<ul>
+    @foreach (var movie in Movies)
+    {
+        <li>@movie.Name (@movie.Year) - <button @onclick="@(() => ShowEditMovie(movie.Id))" class="btn btn-primary">Edit Movie</button></li>
+    }
+</ul>
+
+@code {
+
+    [CascadingParameter] public IModalService Modal { get; set; }
+
+    List<Movies> Movies { get; set; }
+
+    void ShowEditMovie(int movieId)
+    {
+        var parameters = new ModalParameters<EditMovie>()
+        {
+            { component => component.MovieId, movieId }
+        }
+
+        Modal.Show("Edit Movie", parameters);
     }
 
 }
@@ -302,7 +337,7 @@ Below is the caller for the component above. When the result is returned the str
 }
 ```
 
-The example above is only using a string value but you can also pass complex objects back as well. 
+The example above is only using a string value but you can also pass complex objects back as well.
 
 ### Customizing the modal
 
@@ -419,6 +454,7 @@ If you need to use a custom position use `ModalPosition.Custom` and set the CSS 
 ```
 
 #### Animation
+
 The modal also supports some animations.
 
 The following animation types are available out of the box: `ModalAnimation.FadeIn`, `ModalAnimation.FadeOut` and `ModalAnimation.FadeInOut`.
@@ -433,8 +469,8 @@ Or in the `Modal.Show()` method:
 @code {
     void ShowModal()
     {
-        var options = new ModalOptions() 
-        { 
+        var options = new ModalOptions()
+        {
             Animation = ModalAnimation.FadeInOut(1)
         };
 
@@ -447,7 +483,7 @@ Or in the `Modal.Show()` method:
 
 It's possible to have multiple active modal instances at a time. You can find a working example of this in the sample projects but here is some sample code.
 
-Below is a component which being displayed inside a Blazored Modal instance. When a user clicks on the _Delete_ button the `Yes` method is invoked and creates a new modal instance.  
+Below is a component which being displayed inside a Blazored Modal instance. When a user clicks on the _Delete_ button the `Yes` method is invoked and creates a new modal instance.
 
 ```razor
 <div class="simple-form">

--- a/samples/BlazorServer/Pages/PassDataToModalGeneric.razor
+++ b/samples/BlazorServer/Pages/PassDataToModalGeneric.razor
@@ -1,4 +1,4 @@
-﻿@page "/passingdata"
+﻿@page "/passingdatageneric"
 
 <h1>Passing Data to a Modal</h1>
 
@@ -13,9 +13,12 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var parameters = new ModalParameters();")<br />
-                @("parameters.Add(nameof(DisplayMessage.Message), _message);")<br />
-                @("var messageForm = Modal.Show<DisplayMessage>(\"Passing Data\", parameters);")<br />
+                @("var parameters = new ModalParameters<DisplayMessage>")<br />
+                @("{")<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;@("{ component => component.Message, _message }")<br />
+                @("};")<br />
+                <br />
+                @("var messageForm = Modal.Show(\"Passing Data Generic\", parameters);")<br />
                 @("var result = await messageForm.Result;")<br />
                 <br />
                 @("_message = \"\";")
@@ -37,12 +40,16 @@
 
     string _message;
 
+
+
     async Task ShowModal()
     {
-        var parameters = new ModalParameters();
-        parameters.Add(nameof(DisplayMessage.Message), _message);
+        var parameters = new ModalParameters<DisplayMessage>
+        {
+            { component => component.Message, _message }
+        };
 
-        var messageForm = Modal.Show<DisplayMessage>("Passing Data", parameters);
+        var messageForm = Modal.Show("Passing Data Generic", parameters);
         var result = await messageForm.Result;
 
         _message = "";

--- a/samples/BlazorServer/Shared/NavMenu.razor
+++ b/samples/BlazorServer/Shared/NavMenu.razor
@@ -29,6 +29,9 @@
             <NavLink class="nav-link" href="/passingdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data
             </NavLink>
+            <NavLink class="nav-link" href="/passingdatageneric" Match="NavLinkMatch.All">
+                <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data (Generic)
+            </NavLink>
             <NavLink class="nav-link" href="/returningdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Returning Data
             </NavLink>

--- a/samples/BlazorWebAssembly/Pages/PassDataToModal.razor
+++ b/samples/BlazorWebAssembly/Pages/PassDataToModal.razor
@@ -13,11 +13,12 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var messageForm = Modal.Show<MessageForm>();")<br />
+                @("var parameters = new ModalParameters();")<br />
+                @("parameters.Add(nameof(DisplayMessage.Message), _message);")<br />
+                @("var messageForm = Modal.Show<DisplayMessage>(\"Passing Data\", parameters);")<br />
                 @("var result = await messageForm.Result;")<br />
                 <br />
-                @("if (!result.Cancelled)")<br />
-                @("    _message = result.Data.ToString();")
+                @("_message = \"\";")
             </code>
         </p>
     </div>

--- a/samples/BlazorWebAssembly/Pages/PassDataToModalGeneric.razor
+++ b/samples/BlazorWebAssembly/Pages/PassDataToModalGeneric.razor
@@ -1,4 +1,4 @@
-﻿@page "/passingdata"
+﻿@page "/passingdatageneric"
 
 <h1>Passing Data to a Modal</h1>
 
@@ -13,9 +13,12 @@
     <div class="card-body">
         <p class="card-text">
             <code>
-                @("var parameters = new ModalParameters();")<br />
-                @("parameters.Add(nameof(DisplayMessage.Message), _message);")<br />
-                @("var messageForm = Modal.Show<DisplayMessage>(\"Passing Data\", parameters);")<br />
+                @("var parameters = new ModalParameters<DisplayMessage>")<br />
+                @("{")<br />
+                &nbsp;&nbsp;&nbsp;&nbsp;@("{ component => component.Message, _message }")<br />
+                @("};")<br />
+                <br />
+                @("var messageForm = Modal.Show(\"Passing Data Generic\", parameters);")<br />
                 @("var result = await messageForm.Result;")<br />
                 <br />
                 @("_message = \"\";")
@@ -37,12 +40,16 @@
 
     string _message;
 
+
+
     async Task ShowModal()
     {
-        var parameters = new ModalParameters();
-        parameters.Add(nameof(DisplayMessage.Message), _message);
+        var parameters = new ModalParameters<DisplayMessage>
+    {
+            { component => component.Message, _message }
+        };
 
-        var messageForm = Modal.Show<DisplayMessage>("Passing Data", parameters);
+        var messageForm = Modal.Show("Passing Data Generic", parameters);
         var result = await messageForm.Result;
 
         _message = "";

--- a/samples/BlazorWebAssembly/Shared/NavMenu.razor
+++ b/samples/BlazorWebAssembly/Shared/NavMenu.razor
@@ -29,6 +29,9 @@
             <NavLink class="nav-link" href="passingdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data
             </NavLink>
+            <NavLink class="nav-link" href="passingdatageneric" Match="NavLinkMatch.All">
+                <span class="oi oi-loop-square" aria-hidden="true"></span> Passing Data (Generic)
+            </NavLink>
             <NavLink class="nav-link" href="returningdata" Match="NavLinkMatch.All">
                 <span class="oi oi-loop-square" aria-hidden="true"></span> Returning Data
             </NavLink>

--- a/src/Blazored.Modal/Configuration/ModalParameters.cs
+++ b/src/Blazored.Modal/Configuration/ModalParameters.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace Blazored.Modal
 {
@@ -22,7 +27,7 @@ namespace Blazored.Modal
             {
                 return (T)value;
             }
-            
+
             throw new KeyNotFoundException($"{parameterName} does not exist in modal parameters");
         }
 
@@ -35,5 +40,37 @@ namespace Blazored.Modal
 
             return default;
         }
+    }
+
+    public class ModalParameters<TComponent> : ModalParameters, IEnumerable<KeyValuePair<Expression<Func<TComponent, object>>, object>>
+    {
+        public void Add<TParameter>(Expression<Func<TComponent, TParameter>> parameterExpression, TParameter value)
+        {
+            if (parameterExpression.Body is MemberExpression memberExpression)
+            {
+                var property = typeof(TComponent).GetProperty(memberExpression.Member.Name);
+                if (!property.CustomAttributes.Any(a => a.AttributeType == typeof(ParameterAttribute)))
+                {
+                    throw new InvalidOperationException($"Property {memberExpression.Member.Name} is not a component parameter.");
+                }
+                Add(memberExpression.Member.Name, value);
+            }
+            else
+            {
+                throw new InvalidOperationException("Expression is not a member");
+            }
+        }
+
+        public IEnumerator<KeyValuePair<Expression<Func<TComponent, object>>, object>> GetEnumerator()
+        {
+            var parameter = Expression.Parameter(typeof(TComponent));
+
+            return _parameters?.ToDictionary(kvp => (Expression<Func<TComponent, object>>)Expression.Lambda(
+                    Expression.Convert(Expression.Property(parameter, kvp.Key), typeof(object)), parameter),
+                kvp => kvp.Value)
+                .GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Blazored.Modal/Services/IModalService.cs
+++ b/src/Blazored.Modal/Services/IModalService.cs
@@ -30,6 +30,9 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed</param>
         IModalReference Show<TComponent>(string title, ModalParameters parameters) where TComponent : IComponent;
 
+        /// <inheritdoc cref="Show{TComponent}(string, ModalParameters)"/>
+        IModalReference Show<TComponent>(string title, ModalParameters<TComponent> parameters) where TComponent : IComponent;
+
         /// <summary>
         /// Shows a modal containing a <typeparamref name="TComponent"/> with the specified <paramref name="title"/>,
         /// <paramref name="parameters"/> and <paramref name="options"/>.
@@ -38,6 +41,9 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
         IModalReference Show<TComponent>(string title, ModalParameters parameters = null, ModalOptions options = null) where TComponent : IComponent;
+
+        /// <inheritdoc cref="Show{TComponent}(string, ModalParameters, ModalOptions)"/>
+        IModalReference Show<TComponent>(string title, ModalParameters<TComponent> parameters = null, ModalOptions options = null) where TComponent : IComponent;
 
         /// <summary>
         /// Shows a modal containing a <paramref name="component"/>.

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -46,6 +46,12 @@ namespace Blazored.Modal.Services
             return Show<T>(title, parameters, new ModalOptions());
         }
 
+        /// <inheritdoc cref="Show{T}(string, ModalParameters)"/>
+        public IModalReference Show<T>(string title, ModalParameters<T> parameters) where T : IComponent
+        {
+            return Show(title, parameters, new ModalOptions());
+        }
+
         /// <summary>
         /// Shows the modal with the component type using the specified <paramref name="title"/>,
         /// passing the specified <paramref name="parameters"/> and setting a custom CSS style.
@@ -54,6 +60,12 @@ namespace Blazored.Modal.Services
         /// <param name="parameters">Key/Value collection of parameters to pass to component being displayed.</param>
         /// <param name="options">Options to configure the modal.</param>
         public IModalReference Show<T>(string title, ModalParameters parameters, ModalOptions options) where T : IComponent
+        {
+            return Show(typeof(T), title, parameters, options);
+        }
+
+        /// <inheritdoc cref="Show{T}(string, ModalParameters, ModalOptions)"/>
+        public IModalReference Show<T>(string title, ModalParameters<T> parameters, ModalOptions options) where T : IComponent
         {
             return Show(typeof(T), title, parameters, options);
         }

--- a/tests/src/Blazored.Modal.Tests/ModalOptionsTests.cs
+++ b/tests/src/Blazored.Modal.Tests/ModalOptionsTests.cs
@@ -16,7 +16,7 @@ namespace Blazored.Modal.Tests
             Services.AddBlazoredModal();
             JSInterop.Mode = JSRuntimeMode.Loose;
         }
-        
+
         [Fact]
         public void ModalDisplaysSpecifiedTitle()
         {
@@ -31,7 +31,7 @@ namespace Blazored.Modal.Tests
             // Assert
             Assert.Equal(testTitle, cut.Find(".blazored-modal-title").InnerHtml);
         }
-        
+
         [Fact]
         public void ModalDisplaysCorrectPositionClassWhenIsCentered()
         {
@@ -185,6 +185,27 @@ namespace Blazored.Modal.Tests
 
             // Act
             modalService.Show<TestComponent>("", parameters);
+
+            // Assert
+            Assert.Equal(testTitle, cut.Find(".test-component h1").InnerHtml);
+        }
+
+        [Fact]
+        public void ModalDisplaysCorrectContentWhenUsingModalParametersGeneric()
+        {
+            const string testTitle = "Testing Components";
+
+            // Arrange
+            var modalService = Services.GetService<IModalService>();
+
+            var parameters = new ModalParameters<TestComponent>
+            {
+                { component => component.Title, testTitle }
+            };
+            var cut = RenderComponent<BlazoredModal>(CascadingValue(modalService));
+
+            // Act
+            modalService.Show("", parameters);
 
             // Assert
             Assert.Equal(testTitle, cut.Find(".test-component h1").InnerHtml);


### PR DESCRIPTION
This PR adds a new class, ModalParameters<TComponent>, which inherits from the standard ModalParameters, and uses the generic parameter to allow for lambda expression initialization of parameters. It maintains all existing functionality for backward compatibility.

Existing way of showing a modal:
```cs
var parameters = new ModalParameters();
parameters.Add(nameof(DisplayMessage.Message), _message);

var messageForm = Modal.Show<DisplayMessage>("Passing Data", parameters);
```

New way of showing a modal:
```cs
var parameters = new ModalParameters<DisplayMessage>();
parameters.Add(component => component.Message, _message);

var messageForm = Modal.Show("Passing Data", parameters);
```
Additionally, the new type implements IEnumerable, allowing for inline declaration of parameters if you prefer:
```cs
var parameters = new ModalParameters<DisplayMessage>
{
    { component => component.Message, _message} // or { nameof(DisplayMessage.Message), _message}
};

var messageForm = Modal.Show("Passing Data", parameters);
```

Finally, the sample code on PassDataToModal was displaying the incorrect code, so it has been fixed as part of this PR.