### PR TITLE
Confirm cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,30 @@ Or in the `Modal.Show()` method:
 }
 ```
 
+#### Cancel Confirmation
+
+A dialog box can be displayed when the modal is about to be canceled to confirm to the user if the dialog should really be closed.
+To confirmation can be enabled using `ConfirmCancel` and the message can be set with `ConfirmCancelMessage`
+
+`<CascadingBlazoredModal ConfirmCancel="true" ConfirmCancelMessage="Are you sure you want to close the modal?" />`
+
+Or in the `Modal.Show()` method:
+
+```razor
+@code {
+    void ShowModal()
+    {
+        var options = new ModalOptions()
+        {
+            ConfirmCancel = true,
+            ConfirmCancelMessage = "Are you sure you want to close the modal?"
+        };
+
+        Modal.Show<Movies>("My Movies", options);
+    }
+}
+```
+
 #### Disabling background click cancellation
 
 You can disable cancelling the modal by clicking on the background using the `DisableBackgroundCancel` parameter.

--- a/README.md
+++ b/README.md
@@ -347,24 +347,27 @@ Example in the `Modal.Show()` method:
 
 ```razor
 @code {
-    var options = new ModalOptions
+    void ShowModal()
     {
-        ConfimationOnCancelOptions = new ConfirmationModalOptions()
+        var options = new ModalOptions
         {
-            Title = "Are you sure!",
-            Content = "Do you really want to cancel the modal",
-            CloseButtonText = "Yes",
-            CancelButtonText = "No",
-            CloseButtonClass = "btn btn-primary",
-            CancelButtonClass = "btn btn-secondary",
-            OtherOptions = new ModalOptions
+            ConfimationOnCancelOptions = new ConfirmationModalOptions()
             {
-                DisableBackgroundCancel = true,
-                HideCloseButton = true
+                Title = "Are you sure!",
+                Content = "Do you really want to cancel the modal",
+                CloseButtonText = "Yes",
+                CancelButtonText = "No",
+                CloseButtonClass = "btn btn-primary",
+                CancelButtonClass = "btn btn-secondary",
+                OtherOptions = new ModalOptions
+                {
+                    DisableBackgroundCancel = true,
+                    HideCloseButton = true
+                }
             }
-        }
-    };
-    Modal.Show<Confirm>("Confirm Cancel", options);
+        };
+        Modal.Show<Confirm>("Confirm Cancel", options);
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -332,25 +332,39 @@ Or in the `Modal.Show()` method:
 
 #### Cancel Confirmation
 
-A dialog box can be displayed when the modal is about to be canceled to confirm to the user if the dialog should really be closed.
-To confirmation can be enabled using `ConfirmCancel` and the message can be set with `ConfirmCancelMessage`
+A confimation modal can be displayed when the modal is about to be canceled by setting `ConfimationOnCancelOptions` to a new instance of `ConfirmationModalOptions`.
 
-`<CascadingBlazoredModal ConfirmCancel="true" ConfirmCancelMessage="Are you sure you want to close the modal?" />`
+You can change the settings of the confirmation message using the following options:
+- `Title` to set the title of the confirmation
+- `Content` to set the content of the confirmation
+- `CloseButtonText` to set the text of the close button
+- `CancelButtonText` to set the text of the cancel button
+- `CloseButtonClass` to set the class of the close button
+- `CancelButtonClass` to set the class of the cancel button
+- `OtherOptions` to set the normal modal options
 
-Or in the `Modal.Show()` method:
+Example in the `Modal.Show()` method:
 
 ```razor
 @code {
-    void ShowModal()
+    var options = new ModalOptions
     {
-        var options = new ModalOptions()
+        ConfimationOnCancelOptions = new ConfirmationModalOptions()
         {
-            ConfirmCancel = true,
-            ConfirmCancelMessage = "Are you sure you want to close the modal?"
-        };
-
-        Modal.Show<Movies>("My Movies", options);
-    }
+            Title = "Are you sure!",
+            Content = "Do you really want to cancel the modal",
+            CloseButtonText = "Yes",
+            CancelButtonText = "No",
+            CloseButtonClass = "btn btn-primary",
+            CancelButtonClass = "btn btn-secondary",
+            OtherOptions = new ModalOptions
+            {
+                DisableBackgroundCancel = true,
+                HideCloseButton = true
+            }
+        }
+    };
+    Modal.Show<Confirm>("Confirm Cancel", options);
 }
 ```
 

--- a/samples/BlazorServer/Pages/CancelConfirm.razor
+++ b/samples/BlazorServer/Pages/CancelConfirm.razor
@@ -1,52 +1,85 @@
 ﻿@page "/cancelconfirm"
 
-<h1>Confirm before canceling</h1>
+<h1>Confirm before canceling a modal</h1>
 
 <hr class="mb-5" />
 
 <p>
-    A dialog box can be displayed when the modal is canceled by setting <code>ConfirmCancel</code> to <code>true</code>.
+    A confimation modal can be displayed when the modal is about to be canceled by setting <code>ConfimationOnCancelOptions</code> to a new instance of <code>ConfirmationModalOptions</code>.
     <br/>
-    You can then set the message confirmation with <code>ConfirmCancelMessage</code>
+    <br/>
+    You can change the settings of the confirmation message using the following options: <br/>
+    - <code>Title</code> to set the title of the confirmation <br/>
+    - <code>Content</code> to set the content of the confirmation <br/>
+    - <code>CloseButtonText</code> to set the text of the close button <br/>
+    - <code>CancelButtonText</code> to set the text of the cancel button <br/>
+    - <code>CloseButtonClass</code> to set the class of the close button <br/>
+    - <code>CancelButtonClass</code> to set the class of the cancel button <br/>
+    - <code>OtherOptions</code> to set the normal modal options
 </p>
 
 <div class="card mb-4">
     <h5 class="card-header">Setting on a per modal basis</h5>
     <div class="card-body">
-        <p class="card-text">
-            <code>
-                @("var options = new ModalOptions() {ConfirmCancel = true, ConfirmCancelMessage=\"Are you sure\" };")
-                <br />
-                @("Modal.Show<Confirm>(\"Confirm Cancel\", options);")
-            </code>
+        <p class="card-text" style="white-space: break-spaces;">
+            <code>@(@"
+var options = new ModalOptions
+{
+    ConfimationOnCancelOptions = new ConfirmationModalOptions()
+    {
+        Title = ""Are you sure!"",
+        Content = ""Do you really want to cancel the modal"",
+        CloseButtonText = ""Yes"",
+        CancelButtonText = ""No"",
+        CloseButtonClass = ""btn btn-primary"",
+        CancelButtonClass = ""btn btn-secondary"",
+        OtherOptions = new ModalOptions
+        {
+            DisableBackgroundCancel = true,
+            HideCloseButton = true
+        }
+    }
+};
+Modal.Show<Confirm>(""Confirm Cancel"", options);
+")</code>
         </p>
     </div>
 </div>
 
-<div class="card mb-4">
-    <h5 class="card-header">Setting globally for all modals</h5>
-    <div class="card-body">
-        <p class="card-text">
-            <code>
-                @("<BlazoredModal ConfirmCancel=\"true\" />")
-                @("<BlazoredModal ConfirmCancelMessage=\"Are you sure\" />")
-            </code>
-        </p>
-    </div>
-</div>
-
-<button @onclick="ShowCancelConfirm" class="btn btn-primary">Show Modal</button>
+<button @onclick="ShowDefaultCancelConfirm" class="btn btn-primary">Show modal with default confimation</button>
+<button @onclick="ShowCustomCancelConfirm" class="btn btn-primary">Show modal with custom confimation</button>
 
 @code {
 
     [CascadingParameter] public IModalService Modal { get; set; }
 
-    void ShowCancelConfirm()
+    void ShowDefaultCancelConfirm()
     {
         var options = new ModalOptions
         {
-            ConfirmCancel = true,
-            ConfirmCancelMessage = "Are you sure you want to close the modal?"
+            ConfimationOnCancelOptions = new ConfirmationModalOptions()
+        };
+        Modal.Show<Confirm>("Confirm Cancel", options);
+    }
+
+    void ShowCustomCancelConfirm()
+    {
+        var options = new ModalOptions
+        {
+            ConfimationOnCancelOptions = new ConfirmationModalOptions()
+            {
+                Title = "Are you sure!",
+                Content = "Do you really want to cancel the modal",
+                CloseButtonText = "Yes",
+                CancelButtonText = "No",
+                CloseButtonClass = "btn btn-primary",
+                CancelButtonClass = "btn btn-secondary",
+                OtherOptions = new ModalOptions
+                {
+                    DisableBackgroundCancel = true,
+                    HideCloseButton = true
+                }
+            }
         };
         Modal.Show<Confirm>("Confirm Cancel", options);
     }

--- a/samples/BlazorServer/Pages/CancelConfirm.razor
+++ b/samples/BlazorServer/Pages/CancelConfirm.razor
@@ -1,0 +1,53 @@
+﻿@page "/cancelconfirm"
+
+<h1>Confirm before canceling</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A dialog box can be displayed when the modal is canceled by setting <code>ConfirmCancel</code> to <code>true</code>.
+    <br/>
+    You can then set the message confirmation with <code>ConfirmCancelMessage</code>
+</p>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting on a per modal basis</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("var options = new ModalOptions() {ConfirmCancel = true, ConfirmCancelMessage=\"Are you sure\" };")
+                <br />
+                @("Modal.Show<Confirm>(\"Confirm Cancel\", options);")
+            </code>
+        </p>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting globally for all modals</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("<BlazoredModal ConfirmCancel=\"true\" />")
+                @("<BlazoredModal ConfirmCancelMessage=\"Are you sure\" />")
+            </code>
+        </p>
+    </div>
+</div>
+
+<button @onclick="ShowCancelConfirm" class="btn btn-primary">Show Modal</button>
+
+@code {
+
+    [CascadingParameter] public IModalService Modal { get; set; }
+
+    void ShowCancelConfirm()
+    {
+        var options = new ModalOptions
+        {
+            ConfirmCancel = true,
+            ConfirmCancelMessage = "Are you sure you want to close the modal?"
+        };
+        Modal.Show<Confirm>("Confirm Cancel", options);
+    }
+}

--- a/samples/BlazorServer/Shared/NavMenu.razor
+++ b/samples/BlazorServer/Shared/NavMenu.razor
@@ -47,6 +47,9 @@
             <NavLink class="nav-link" href="customoverlay" Match="NavLinkMatch.All">
                 <span class="oi oi-eye" aria-hidden="true"></span> Custom Overlay
             </NavLink>
+            <NavLink class="nav-link" href="cancelconfirm" Match="NavLinkMatch.All">
+                <span class="oi oi-x" aria-hidden="true"></span> Confirm Cancel
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/samples/BlazorWebAssembly/Pages/CancelConfirm.razor
+++ b/samples/BlazorWebAssembly/Pages/CancelConfirm.razor
@@ -1,52 +1,85 @@
 ﻿@page "/cancelconfirm"
 
-<h1>Confirm before canceling</h1>
+<h1>Confirm before canceling a modal</h1>
 
 <hr class="mb-5" />
 
 <p>
-    A dialog box can be displayed when the modal is canceled by setting <code>ConfirmCancel</code> to <code>true</code>.
+    A confimation modal can be displayed when the modal is about to be canceled by setting <code>ConfimationOnCancelOptions</code> to a new instance of <code>ConfirmationModalOptions</code>.
     <br/>
-    You can then set the message confirmation with <code>ConfirmCancelMessage</code>
+    <br/>
+    You can change the settings of the confirmation message using the following options: <br/>
+    - <code>Title</code> to set the title of the confirmation <br/>
+    - <code>Content</code> to set the content of the confirmation <br/>
+    - <code>CloseButtonText</code> to set the text of the close button <br/>
+    - <code>CancelButtonText</code> to set the text of the cancel button <br/>
+    - <code>CloseButtonClass</code> to set the class of the close button <br/>
+    - <code>CancelButtonClass</code> to set the class of the cancel button <br/>
+    - <code>OtherOptions</code> to set the normal modal options
 </p>
 
 <div class="card mb-4">
     <h5 class="card-header">Setting on a per modal basis</h5>
     <div class="card-body">
-        <p class="card-text">
-            <code>
-                @("var options = new ModalOptions() {ConfirmCancel = true, ConfirmCancelMessage=\"Are you sure\" };")
-                <br />
-                @("Modal.Show<Confirm>(\"Confirm Cancel\", options);")
-            </code>
+        <p class="card-text" style="white-space: break-spaces;">
+            <code>@(@"
+var options = new ModalOptions
+{
+    ConfimationOnCancelOptions = new ConfirmationModalOptions()
+    {
+        Title = ""Are you sure!"",
+        Content = ""Do you really want to cancel the modal"",
+        CloseButtonText = ""Yes"",
+        CancelButtonText = ""No"",
+        CloseButtonClass = ""btn btn-primary"",
+        CancelButtonClass = ""btn btn-secondary"",
+        OtherOptions = new ModalOptions
+        {
+            DisableBackgroundCancel = true,
+            HideCloseButton = true
+        }
+    }
+};
+Modal.Show<Confirm>(""Confirm Cancel"", options);
+")</code>
         </p>
     </div>
 </div>
 
-<div class="card mb-4">
-    <h5 class="card-header">Setting globally for all modals</h5>
-    <div class="card-body">
-        <p class="card-text">
-            <code>
-                @("<BlazoredModal ConfirmCancel=\"true\" />")
-                @("<BlazoredModal ConfirmCancelMessage=\"Are you sure\" />")
-            </code>
-        </p>
-    </div>
-</div>
-
-<button @onclick="ShowCancelConfirm" class="btn btn-primary">Show Modal</button>
+<button @onclick="ShowDefaultCancelConfirm" class="btn btn-primary">Show modal with default confimation</button>
+<button @onclick="ShowCustomCancelConfirm" class="btn btn-primary">Show modal with custom confimation</button>
 
 @code {
 
     [CascadingParameter] public IModalService Modal { get; set; }
 
-    void ShowCancelConfirm()
+    void ShowDefaultCancelConfirm()
     {
         var options = new ModalOptions
         {
-            ConfirmCancel = true,
-            ConfirmCancelMessage = "Are you sure you want to close the modal?"
+            ConfimationOnCancelOptions = new ConfirmationModalOptions()
+        };
+        Modal.Show<Confirm>("Confirm Cancel", options);
+    }
+
+    void ShowCustomCancelConfirm()
+    {
+        var options = new ModalOptions
+        {
+            ConfimationOnCancelOptions = new ConfirmationModalOptions()
+            {
+                Title = "Are you sure!",
+                Content = "Do you really want to cancel the modal",
+                CloseButtonText = "Yes",
+                CancelButtonText = "No",
+                CloseButtonClass = "btn btn-primary",
+                CancelButtonClass = "btn btn-secondary",
+                OtherOptions = new ModalOptions
+                {
+                    DisableBackgroundCancel = true,
+                    HideCloseButton = true
+                }
+            }
         };
         Modal.Show<Confirm>("Confirm Cancel", options);
     }

--- a/samples/BlazorWebAssembly/Pages/CancelConfirm.razor
+++ b/samples/BlazorWebAssembly/Pages/CancelConfirm.razor
@@ -1,0 +1,53 @@
+﻿@page "/cancelconfirm"
+
+<h1>Confirm before canceling</h1>
+
+<hr class="mb-5" />
+
+<p>
+    A dialog box can be displayed when the modal is canceled by setting <code>ConfirmCancel</code> to <code>true</code>.
+    <br/>
+    You can then set the message confirmation with <code>ConfirmCancelMessage</code>
+</p>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting on a per modal basis</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("var options = new ModalOptions() {ConfirmCancel = true, ConfirmCancelMessage=\"Are you sure\" };")
+                <br />
+                @("Modal.Show<Confirm>(\"Confirm Cancel\", options);")
+            </code>
+        </p>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <h5 class="card-header">Setting globally for all modals</h5>
+    <div class="card-body">
+        <p class="card-text">
+            <code>
+                @("<BlazoredModal ConfirmCancel=\"true\" />")
+                @("<BlazoredModal ConfirmCancelMessage=\"Are you sure\" />")
+            </code>
+        </p>
+    </div>
+</div>
+
+<button @onclick="ShowCancelConfirm" class="btn btn-primary">Show Modal</button>
+
+@code {
+
+    [CascadingParameter] public IModalService Modal { get; set; }
+
+    void ShowCancelConfirm()
+    {
+        var options = new ModalOptions
+        {
+            ConfirmCancel = true,
+            ConfirmCancelMessage = "Are you sure you want to close the modal?"
+        };
+        Modal.Show<Confirm>("Confirm Cancel", options);
+    }
+}

--- a/samples/BlazorWebAssembly/Shared/NavMenu.razor
+++ b/samples/BlazorWebAssembly/Shared/NavMenu.razor
@@ -50,6 +50,9 @@
             <NavLink class="nav-link" href="customoverlay" Match="NavLinkMatch.All">
                 <span class="oi oi-eye" aria-hidden="true"></span> Custom Overlay
             </NavLink>
+            <NavLink class="nav-link" href="cancelconfirm" Match="NavLinkMatch.All">
+                <span class="oi oi-x" aria-hidden="true"></span> Confirm Cancel
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/src/Blazored.Modal/BlazoredConfirmationModal.razor
+++ b/src/Blazored.Modal/BlazoredConfirmationModal.razor
@@ -1,0 +1,11 @@
+﻿@inject IModalService ModalService
+
+<div>
+    @if (!string.IsNullOrWhiteSpace(Options.Content))
+    {
+        <p>@Options.Content</p>
+    }
+
+    <button @onclick="Close" class="@Options.CloseButtonClass">@Options.CloseButtonText</button>
+    <button @onclick="Cancel" class="@Options.CancelButtonClass">@Options.CancelButtonText</button>
+</div>

--- a/src/Blazored.Modal/BlazoredConfirmationModal.razor.cs
+++ b/src/Blazored.Modal/BlazoredConfirmationModal.razor.cs
@@ -1,0 +1,25 @@
+﻿using Blazored.Modal.Services;
+using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
+
+namespace Blazored.Modal
+{
+    partial class BlazoredConfirmationModal
+    {
+        [CascadingParameter] BlazoredModalInstance BlazoredModal { get; set; }
+
+        [Parameter] public ConfirmationModalOptions Options {  get; set; }
+
+        async Task Close() => await BlazoredModal.CloseAsync(ModalResult.Ok(true));
+        async Task Cancel() => await BlazoredModal.CancelAsync();
+
+        protected override void OnInitialized()
+        {
+            if (Options == null) {
+                Options = new ConfirmationModalOptions();
+            }
+
+            base.OnInitialized();
+        }
+    }
+}

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -1,4 +1,4 @@
-﻿using Blazored.Modal.Services;
+using Blazored.Modal.Services;
 using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
@@ -25,6 +25,8 @@ namespace Blazored.Modal
         private bool HideCloseButton { get; set; }
         private bool DisableBackgroundCancel { get; set; }
         private string OverlayCustomClass { get; set; }
+        private bool ConfirmCancel { get; set; }
+        private string ConfirmCancelMessage { get; set; }
         private ModalAnimation Animation { get; set; }
         private bool ActivateFocusTrap { get; set; }
         private string AnimationDuration
@@ -103,6 +105,13 @@ namespace Blazored.Modal
         /// </summary>
         public async Task CancelAsync()
         {
+            if (ConfirmCancel)
+            {
+                bool didConfirm = await JSRuntime.InvokeAsync<bool>("confirm", Options.ConfirmCancelMessage);
+
+                if (!didConfirm) return;
+            }
+
             await CloseAsync(ModalResult.Cancel());
         }
 
@@ -117,6 +126,8 @@ namespace Blazored.Modal
             UseCustomLayout = SetUseCustomLayout();
             OverlayCustomClass = SetOverlayCustomClass();
             ActivateFocusTrap = SetActivateFocusTrap();
+            ConfirmCancel = SetConfirmCancel();
+            ConfirmCancelMessage = SetConfirmCancelMessage();
         }
 
         private bool SetUseCustomLayout()
@@ -284,6 +295,28 @@ namespace Blazored.Modal
                 return GlobalModalOptions.ActivateFocusTrap.Value;
 
             return true; // Default to true to match old behaviour
+        }
+
+        private bool SetConfirmCancel()
+        {
+            if (Options.ConfirmCancel.HasValue)
+                return Options.ConfirmCancel.Value;
+
+            if (GlobalModalOptions.ConfirmCancel.HasValue)
+                return GlobalModalOptions.ConfirmCancel.Value;
+
+            return false;
+        }
+
+        private string SetConfirmCancelMessage()
+        {
+            if (!string.IsNullOrWhiteSpace(Options.ConfirmCancelMessage))
+                return Options.ConfirmCancelMessage;
+
+            if (!string.IsNullOrWhiteSpace(GlobalModalOptions.ConfirmCancelMessage))
+                return GlobalModalOptions.ConfirmCancelMessage;
+
+            return string.Empty;
         }
 
         private async Task HandleBackgroundClick()

--- a/src/Blazored.Modal/Configuration/ConfirmationModalOptions.cs
+++ b/src/Blazored.Modal/Configuration/ConfirmationModalOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Blazored.Modal
+{
+    public class ConfirmationModalOptions
+    {
+        public ModalOptions OtherOptions { get; set; } = new ModalOptions();
+        public string Title { get; set; } = "Are you sure you want to close the modal.";
+        public string Content { get; set; }
+        public string CloseButtonText { get; set; } = "Yes";
+        public string CloseButtonClass { get; set; } = "btn btn-outline-danger";
+        public string CancelButtonText { get; set; } = "No";
+        public string CancelButtonClass { get; set; } = "btn btn-primary";
+    }
+}

--- a/src/Blazored.Modal/Configuration/ModalOptions.cs
+++ b/src/Blazored.Modal/Configuration/ModalOptions.cs
@@ -13,5 +13,7 @@
         public bool? UseCustomLayout { get; set; }
         public bool? ContentScrollable { get; set; }
         public bool? ActivateFocusTrap { get; set; }
+        public bool? ConfirmCancel { get; set; }
+        public string ConfirmCancelMessage { get; set; }
     }
 }

--- a/src/Blazored.Modal/Configuration/ModalOptions.cs
+++ b/src/Blazored.Modal/Configuration/ModalOptions.cs
@@ -13,7 +13,6 @@
         public bool? UseCustomLayout { get; set; }
         public bool? ContentScrollable { get; set; }
         public bool? ActivateFocusTrap { get; set; }
-        public bool? ConfirmCancel { get; set; }
-        public string ConfirmCancelMessage { get; set; }
+        public ConfirmationModalOptions ConfimationOnCancelOptions { get; set; }
     }
 }


### PR DESCRIPTION
Added the ability to display a dialogue box to confirm if the modal should really be canceled.

This will help accidental clicks outside the screen and/or confirming with the user that they know nothing will be saved when working with a modal that saves data.