### PR TITLE
Fix ModalResult not returning the correct DataType using Ok<T>(T result) method.

### DIFF
--- a/src/Blazored.Modal/Services/ModalResult.cs
+++ b/src/Blazored.Modal/Services/ModalResult.cs
@@ -15,7 +15,7 @@ namespace Blazored.Modal.Services
             Cancelled = cancelled;
         }
 
-        public static ModalResult Ok<T>(T result) => Ok(result, default);
+        public static ModalResult Ok<T>(T result) => Ok(result, typeof(T));
 
         public static ModalResult Ok<T>(T result, Type modalType) => new ModalResult(result, modalType, false);
 


### PR DESCRIPTION
The `default` keyword was returning the `System.Object` type all the time instead of the expected `typeof(T)` value.
This was breaking the 'long running task' sample on the 'OK button' case.