### PR TITLE
BlazoredModalInstance.Options and Parameters should not be null

### DIFF
--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -130,7 +130,7 @@ namespace Blazored.Modal.Services
             var modalInstance = new RenderFragment(builder =>
             {
                 builder.OpenComponent<BlazoredModalInstance>(0);
-                builder.AddAttribute(1, "Options", options);
+                builder.AddAttribute(1, "Options", options ?? new ModalOptions());
                 builder.AddAttribute(2, "Title", title);
                 builder.AddAttribute(3, "Content", modalContent);
                 builder.AddAttribute(4, "Id", modalInstanceId);

--- a/src/Blazored.Modal/Services/ModalService.cs
+++ b/src/Blazored.Modal/Services/ModalService.cs
@@ -110,6 +110,9 @@ namespace Blazored.Modal.Services
         /// <param name="options">Options to configure the modal.</param>
         public IModalReference Show(Type contentComponent, string title, ModalParameters parameters, ModalOptions options)
         {
+            if (parameters == null) parameters = new ModalParameters();
+            if (options == null) options = new ModalOptions();
+            
             if (!typeof(IComponent).IsAssignableFrom(contentComponent))
             {
                 throw new ArgumentException($"{contentComponent.FullName} must be a Blazor Component");
@@ -130,7 +133,7 @@ namespace Blazored.Modal.Services
             var modalInstance = new RenderFragment(builder =>
             {
                 builder.OpenComponent<BlazoredModalInstance>(0);
-                builder.AddAttribute(1, "Options", options ?? new ModalOptions());
+                builder.AddAttribute(1, "Options", options);
                 builder.AddAttribute(2, "Title", title);
                 builder.AddAttribute(3, "Content", modalContent);
                 builder.AddAttribute(4, "Id", modalInstanceId);

--- a/tests/src/Blazored.Modal.Tests/ModalOptionsTests.cs
+++ b/tests/src/Blazored.Modal.Tests/ModalOptionsTests.cs
@@ -172,6 +172,48 @@ namespace Blazored.Modal.Tests
         }
 
         [Fact]
+        public void ModalDisplaysWithNullModalParametersAndNullModalOptions()
+        {
+            // Arrange
+            var modalService = Services.GetService<IModalService>();
+            var cut = RenderComponent<BlazoredModal>(CascadingValue(modalService));
+
+            // Act
+            modalService.Show<TestComponent>("", null, null);
+
+            // Assert
+            Assert.Equal(TestComponent.DefaultTitle, cut.Find(".test-component h1").InnerHtml);
+        }
+
+        [Fact]
+        public void ModalDisplaysWithNullModalParameters()
+        {
+            // Arrange
+            var modalService = Services.GetService<IModalService>();
+            var cut = RenderComponent<BlazoredModal>(CascadingValue(modalService));
+
+            // Act
+            modalService.Show<TestComponent>("", (ModalParameters)null);
+
+            // Assert
+            Assert.Equal(TestComponent.DefaultTitle, cut.Find(".test-component h1").InnerHtml);
+        }
+
+        [Fact]
+        public void ModalDisplaysWithNullModalOptions()
+        {
+            // Arrange
+            var modalService = Services.GetService<IModalService>();
+            var cut = RenderComponent<BlazoredModal>(CascadingValue(modalService));
+
+            // Act
+            modalService.Show<TestComponent>("", (ModalOptions)null);
+
+            // Assert
+            Assert.Equal(TestComponent.DefaultTitle, cut.Find(".test-component h1").InnerHtml);
+        }
+
+        [Fact]
         public void ModalDisplaysCorrectContentWhenUsingModalParameters()
         {
             var testTitle = "Testing Components";


### PR DESCRIPTION
`BlazoredModalInstance.Options` or `BlazoredModalInstance.Parameters` properties should never be set to null. However it's "expected" to work when using the `IModalService.Show<TComponent>(string title, ModalParameters parameters = null, ModalOptions options = null)` method which allows users to set null parameters. But if you use null, the component fails to initialize.