### PR TITLE
Sample website sidebar fix

### DIFF
--- a/samples/BlazorServer/Shared/MainLayout.razor.css
+++ b/samples/BlazorServer/Shared/MainLayout.razor.css
@@ -55,6 +55,7 @@ main {
         height: 100vh;
         position: sticky;
         top: 0;
+        overflow-y: scroll;
     }
 
     .top-row {

--- a/samples/BlazorWebAssembly/Shared/MainLayout.razor.css
+++ b/samples/BlazorWebAssembly/Shared/MainLayout.razor.css
@@ -60,6 +60,7 @@ main {
         height: 100vh;
         position: sticky;
         top: 0;
+        overflow-y: scroll;
     }
 
     .top-row {


### PR DESCRIPTION
Hello, in the sample website (https://blazored.github.io/Modal/) the sidebar is "broken" when you scroll the page.

![Capturadqe](https://user-images.githubusercontent.com/34100964/165866720-60991016-92f4-4388-a133-1b7346b96b41.PNG)

So I added a simple css rule to fix it (`overflow-y: scroll;`).

After the change it looks like this:

![Capturefafa](https://user-images.githubusercontent.com/34100964/165866767-f325a7d9-c560-4190-b708-c0cce870e671.PNG)

