### PR TITLE
fluent "add" for modal parameters

### DIFF
--- a/src/Blazored.Modal/Configuration/ModalParameters.cs
+++ b/src/Blazored.Modal/Configuration/ModalParameters.cs
@@ -11,8 +11,11 @@ public class ModalParameters : IEnumerable<KeyValuePair<string, object>>
         Parameters = new Dictionary<string, object>();
     }
 
-    public void Add(string parameterName, object value) 
-        => Parameters[parameterName] = value;
+    public ModalParameters Add(string parameterName, object value)
+    {
+        Parameters[parameterName] = value;
+        return this;
+    }
 
     public T Get<T>(string parameterName)
     {


### PR DESCRIPTION
small PR that updates the `Add` method to return the instance of `ModalParameters`, so that this:

```csharp
var parameters = new ModalParameters();
parameters.Add("Name", "My Name");
parameters.Add("Number", 42);
```

can also be written as:

```csharp
var parameters = new ModalParameters()
    .Add("Name", "My Name")
    .Add("Number", 42);
```