### PR TITLE
Proposed tweaks for FocusTrap

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -10,7 +10,7 @@ else
          @ref="_modalReference" 
          @onclick="HandleBackgroundClick">
 
-        <FocusTrap @ref="_focusTrap" IsActive="ActivateFocusTrap">
+        <FocusTrap @ref="FocusTrap" IsActive="ActivateFocusTrap">
             <div class="@ModalClass" role="dialog" aria-modal="true" @onclick:stopPropagation="true">
                 @if (!HideHeader)
                 {

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -23,12 +23,12 @@ public partial class BlazoredModalInstance : IDisposable
     private string? OverlayCustomClass { get; set; }
     private ModalAnimationType? AnimationType { get; set; }
     private bool ActivateFocusTrap { get; set; }
-
     public bool UseCustomLayout { get; set; }
+    public FocusTrap? FocusTrap { get; set; }
+
 
     [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "This is assigned in Razor code and isn't currently picked up by the tooling.")]
     private ElementReference _modalReference;
-    public FocusTrap? FocusTrap = default;
     private bool _setFocus;
 
     // Temporarily add a tabindex of -1 to the close button so it doesn't get selected as the first element by activateFocusTrap

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -28,7 +28,7 @@ public partial class BlazoredModalInstance : IDisposable
 
     [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "This is assigned in Razor code and isn't currently picked up by the tooling.")]
     private ElementReference _modalReference;
-    private FocusTrap _focusTrap = default!;
+    public FocusTrap? FocusTrap = default;
     private bool _setFocus;
 
     // Temporarily add a tabindex of -1 to the close button so it doesn't get selected as the first element by activateFocusTrap
@@ -50,7 +50,10 @@ public partial class BlazoredModalInstance : IDisposable
     {
         if (_setFocus)
         {
-            await _focusTrap.SetFocus();
+            if (FocusTrap is not null)
+            {
+                await FocusTrap.SetFocus();
+            }
             _setFocus = false;
         }
     }


### PR DESCRIPTION
Hi Chris,

I've got custom dialogs in my setup and was having trouble with the preview packages. These tweaks sorted it for me. 

Null check on FocusTrap in OnAfterRenderAsync
 * If using custom dialogs _focusTrap is not set but there's no null check on the render 
 
Make FocusTrap field public so it can be used in custom dialogs
 * Changing to public means we can add FocusTrap in custom dialogs if we want to (and the null ref check prevents errors if we don't) 
 * Renamed _focusTrap to FocusTrap and set the variable annotation as nullable

I was tempted to change

```
    private void AttemptFocus() 
        => _setFocus = FocusTrap != null;

```

But wasn't sure if there's a time before the first render when the @ref gets set that AttemptFocus might be called

Cheers,

Danny
