### PR TITLE
Sample website sidebar fix

### DIFF
--- a/samples/BlazorServer/Shared/MainLayout.razor.css
+++ b/samples/BlazorServer/Shared/MainLayout.razor.css
@@ -55,6 +55,7 @@ main {
         height: 100vh;
         position: sticky;
         top: 0;
+        overflow-y: auto;
     }
 
     .top-row {

--- a/samples/BlazorWebAssembly/Shared/MainLayout.razor.css
+++ b/samples/BlazorWebAssembly/Shared/MainLayout.razor.css
@@ -60,6 +60,7 @@ main {
         height: 100vh;
         position: sticky;
         top: 0;
+        overflow-y: auto;
     }
 
     .top-row {


### PR DESCRIPTION
Hi, I opened a pull request a while ago that got closed as it was supposed to get fixed in a different PR.
https://github.com/Blazored/Modal/pull/397

But it looks like the demo app (https://blazored.github.io/Modal/) still has the same issue when the height of the browser is smaller than the height of the sidebar.

![sidebar](https://user-images.githubusercontent.com/34100964/188027015-345f93c6-f64f-4b4f-bf21-fb21dd4be92a.PNG)

Adding `overflow-y: auto;` to the `.sidebar` style in `MainLayout.razor.css` fixes the issue.