### PR TITLE
Error in README file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/samples/BlazorServer/bin/Debug/net6.0/BlazorServer.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/samples/BlazorServer",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/samples/BlazorServer/BlazorServer.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/samples/BlazorServer/BlazorServer.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/samples/BlazorServer/BlazorServer.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add the `<CascadingBlazoredModal />` component into your applications *App.razor
 
 ### 4. Add reference to style sheet & javascript reference
 
-Add the following line to the `head` tag of your `_Host.cshtml` (Blazor Server) or `index.html` (Blazor WebAssembly).
+Add the following line to the `head` tag of your `_Layout.cshtml` (Blazor Server) or `index.html` (Blazor WebAssembly).
 
 ```html
 <link href="_content/Blazored.Modal/blazored-modal.css" rel="stylesheet" />

--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>e5f54cc4-188a-4cf2-9a7f-3943e78eeef4</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Step 4 in the README file specifies the .css and .js files be called from _Host.cshtml, however in .net6 _Host.cshtml just builds the app. The file containing all the .css and .js should be _Layout.cshtml