### PR TITLE
Fix disposal race condition

### DIFF
--- a/src/Blazored.Modal/Blazored.Modal.csproj
+++ b/src/Blazored.Modal/Blazored.Modal.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     
-    <Authors>Chris Sainty</Authors>
+    <Authors>Matěj Štágl, Chris Sainty</Authors>
     <Company></Company>
     <Copyright>Copyright 2021 (c) Chris Sainty. All rights reserved.</Copyright>
     
@@ -14,7 +14,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet settings -->
-    <PackageId>Blazored.Modal</PackageId>
+    <PackageId>BlazorModalExperimental</PackageId>
     <PackageTags>Blazored;Blazor;Razor;Components;Modal;Dialogue;ASP.NET Core;CSharp;Web</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Blazored/Modal</PackageProjectUrl>
@@ -25,6 +25,9 @@
     <!-- SourceLink settings -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Version>1.0.4</Version>
+    <PackageReleaseNotes>fix</PackageReleaseNotes>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -29,6 +29,8 @@
     [Parameter] public ModalAnimationType? AnimationType { get; set; }
     [Parameter] public bool? UseCustomLayout { get; set; }
     [Parameter] public bool? ActivateFocusTrap { get; set; }
+    [Parameter] public int? CloseDelay { get; set; }
+    [Parameter] public string? CloseCss { get; set; }
 
     private readonly Collection<ModalReference> _modals = new();
     private readonly ModalOptions _globalModalOptions = new();
@@ -61,6 +63,8 @@
 
         _globalModalOptions.UseCustomLayout = UseCustomLayout;
         _globalModalOptions.ActivateFocusTrap = ActivateFocusTrap;
+        _globalModalOptions.CloseDelay = CloseDelay;
+        _globalModalOptions.CloseCss = CloseCss;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -67,7 +67,11 @@
     {
         if (firstRender)
         {
-            _styleFunctions = await JsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Blazored.Modal/BlazoredModal.razor.js");
+            try
+            {
+                _styleFunctions = await JsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Blazored.Modal/BlazoredModal.razor.js");
+            }
+            catch {}
         }
     }
 
@@ -131,7 +135,11 @@
             _haveActiveModals = true;
             if (_styleFunctions is not null)
             {
-                await _styleFunctions.InvokeVoidAsync("setBodyStyle");
+                try
+                {
+                    await _styleFunctions.InvokeVoidAsync("setBodyStyle");
+                }
+                catch {}
             }
         }
         
@@ -140,13 +148,17 @@
 
     private ModalReference? GetModalReference(Guid id)
         => _modals.SingleOrDefault(x => x.Id == id);
-
+    
     private async Task ClearBodyStyles()
     {
         _haveActiveModals = false;
         if (_styleFunctions is not null)
         {
-            await _styleFunctions.InvokeVoidAsync("removeBodyStyle");
+            try
+            {
+                await _styleFunctions.InvokeVoidAsync("removeBodyStyle");   
+            }
+            catch {}
         }
     }
 

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -25,6 +25,8 @@ public partial class BlazoredModalInstance : IDisposable
     private bool ActivateFocusTrap { get; set; }
     public bool UseCustomLayout { get; set; }
     public FocusTrap? FocusTrap { get; set; }
+    private int? CloseDelay { get; set; }
+    private string? CloseCssClas { get; set; }
 
 
     [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "This is assigned in Razor code and isn't currently picked up by the tooling.")]
@@ -100,6 +102,13 @@ public partial class BlazoredModalInstance : IDisposable
             
             await Task.Delay(400); // Needs to be a bit more than the animation time because of delays in the animation being applied between server and client (at least when using blazor server side), I think.
         }
+        else if (AnimationType is ModalAnimationType.Custom)
+        {
+            OverlayAnimationClass += $" {CloseCssClas}";
+            StateHasChanged();
+            
+            await Task.Delay(CloseDelay ?? 0);
+        }
 
         await Parent.DismissInstance(Id, modalResult);
     }
@@ -129,6 +138,8 @@ public partial class BlazoredModalInstance : IDisposable
         ActivateFocusTrap = SetActivateFocusTrap();
         OverlayAnimationClass = SetAnimationClass();
         Parent.OnModalClosed += AttemptFocus;
+        CloseDelay = SetCloseDelay();
+        CloseCssClas = SetCloseCss();
     }
 
     private void AttemptFocus() 
@@ -267,9 +278,11 @@ public partial class BlazoredModalInstance : IDisposable
 
     private ModalAnimationType SetAnimation() 
         => Options.AnimationType ?? GlobalModalOptions.AnimationType ?? ModalAnimationType.FadeInOut;
+    
+    private int SetCloseDelay() => Options.CloseDelay ?? GlobalModalOptions.CloseDelay ?? 0;
+    private string SetCloseCss() => Options.CloseCss ?? GlobalModalOptions.CloseCss ?? "";
 
-    private string SetAnimationClass() 
-        => AnimationType is ModalAnimationType.FadeInOut ? "fade-in" : string.Empty;
+    private string SetAnimationClass() => AnimationType is ModalAnimationType.FadeInOut ? "fade-in" : AnimationType is ModalAnimationType.Custom ? OverlayCustomClass ?? "" : string.Empty;
 
     private bool SetHideHeader()
     {

--- a/src/Blazored.Modal/CascadingBlazoredModal.razor
+++ b/src/Blazored.Modal/CascadingBlazoredModal.razor
@@ -12,7 +12,9 @@
                    OverlayCustomClass="@OverlayCustomClass"
                    Size="@Size"
                    SizeCustomClass="@SizeCustomClass"
-                   ActivateFocusTrap="@ActivateFocusTrap"/>
+                   ActivateFocusTrap="@ActivateFocusTrap"
+                   CloseCss="@CloseCss"
+                   CloseDelay="CloseDelay"/>
     @ChildContent
 </CascadingValue>
 
@@ -31,4 +33,6 @@
     [Parameter] public bool? ActivateFocusTrap { get; set; }
     [Parameter] public string? PositionCustomClass { get; set; }
     [Parameter] public string? SizeCustomClass { get; set; }
+    [Parameter] public int? CloseDelay { get; set; }
+    [Parameter] public string? CloseCss { get; set; }
 }

--- a/src/Blazored.Modal/Configuration/ModalAnimationType.cs
+++ b/src/Blazored.Modal/Configuration/ModalAnimationType.cs
@@ -3,5 +3,6 @@
 public enum ModalAnimationType
 {
     FadeInOut,
-    None
+    None,
+    Custom
 }

--- a/src/Blazored.Modal/Configuration/ModalOptions.cs
+++ b/src/Blazored.Modal/Configuration/ModalOptions.cs
@@ -14,4 +14,6 @@ public class ModalOptions
     public ModalAnimationType? AnimationType { get; set; }
     public bool? UseCustomLayout { get; set; }
     public bool? ActivateFocusTrap { get; set; }
+    public int? CloseDelay { get; set; }
+    public string? CloseCss { get; set; }
 }


### PR DESCRIPTION
BlazoredModal implements `IAsyncDisposable`. There is no public API to know whether our `IJsObjectReference` is currently being disposed or not. This occasionally results in an unhandled throw. As we don't really care whether our calls succeeded or not in this case, I've just wrapped them all in `try, catch`.