### PR TITLE
Control background click mouse events

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -7,11 +7,13 @@
 else
 {
     <div class="bm-container @Position @OverlayCustomClass @OverlayAnimationClass"
-         @ref="_modalReference" 
-         @onclick="HandleBackgroundClick">
+        @ref="_modalReference"
+        @onmousedown="ListenToBackgroundClick"
+        @onmouseup="HandleBackgroundClick"
+        @onclick="StopListeningToBackgroundClick">
 
         <FocusTrap @ref="FocusTrap" IsActive="ActivateFocusTrap">
-            <div class="@ModalClass" role="dialog" aria-modal="true" @onclick:stopPropagation="true">
+            <div class="@ModalClass" role="dialog" aria-modal="true" @onmouseup:stopPropagation="true" @onmousedown:stopPropagation="true">
                 @if (!HideHeader)
                 {
                     <div class="bm-header">

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -31,6 +31,7 @@ public partial class BlazoredModalInstance : IDisposable
     private ElementReference _modalReference;
     private bool _setFocus;
     private bool _disableNextRender;
+    private bool _listenToBackgroundClicks;
 
     // Temporarily add a tabindex of -1 to the close button so it doesn't get selected as the first element by activateFocusTrap
     private readonly Dictionary<string, object> _closeBtnAttributes = new() { { "tabindex", "-1" } };
@@ -334,8 +335,18 @@ public partial class BlazoredModalInstance : IDisposable
             return;
         }
 
-        await CancelAsync();
+        if (_listenToBackgroundClicks)
+        {
+            await CancelAsync();
+            _listenToBackgroundClicks = false;
+        }
     }
+
+    private void ListenToBackgroundClick()
+    => _listenToBackgroundClicks = true;
+
+    private void StopListeningToBackgroundClick()
+        => _listenToBackgroundClicks = false;
 
     void IDisposable.Dispose() 
         => Parent.OnModalClosed -= AttemptFocus;


### PR DESCRIPTION
Mouse click, down, and up events will be handled to avoid closing the modal by accident. This avoids accidents when highlighting text and dragging the mouse cursor outside of the modal area (into the background).

Solves #518

This also allows the user to escape closing the modal by dragging the mouse click back into the modal content area.