### PR TITLE
Use computed style to consider the real values

### DIFF
--- a/src/Blazored.Modal/BlazoredModal.razor.js
+++ b/src/Blazored.Modal/BlazoredModal.razor.js
@@ -1,5 +1,6 @@
 ﻿const el = document.body;
-const originalProps = {overflow: el.style.overflow, paddingRight: el.style.paddingRight};
+const computedBodyStyle = getComputedStyle(el);
+const originalProps = { overflow: computedBodyStyle.overflow, paddingRight: computedBodyStyle.paddingRight };
 const getScrollBarWidth = () => {
     let el = document.createElement("div");
     el.style.cssText = "overflow:scroll; visibility:hidden; position:absolute;";


### PR DESCRIPTION
Currently, if someone uses a class to apply an `overflow` value to the `body`, the value won't be reset to default in `removeBodyStyle`.

This way, the current computed value is used.