### PR TITLE
Fix modal size when using position middle

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor.css
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.css
@@ -98,7 +98,6 @@
 
 .position-middle {
     display: grid;
-    justify-content: center;
     align-items: center;
 }
 


### PR DESCRIPTION
In https://github.com/Blazored/Modal/pull/556, display grid was used to position a modal in the middle. If you have a modal with Position Middle and Size Large or ExtraLarge, the width of the modal stays small. The justify-content-center isn't neccessary anymore and prevents the modal size to work.