### PR TITLE
Fix bug with BlazoredModalInstance SetTitle with nested modals

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -11,7 +11,7 @@ public partial class BlazoredModalInstance : IDisposable
 
     [Parameter, EditorRequired] public RenderFragment Content { get; set; } = default!;
     [Parameter, EditorRequired] public ModalOptions Options { get; set; } = default!;
-    [Parameter] public string? Title { get => _title; set => _title ??= value; }
+    [Parameter] public string? Title { get => _title; init => _title ??= value; }
     [Parameter] public Guid Id { get; set; }
 
     private string? Position { get; set; }

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -11,7 +11,7 @@ public partial class BlazoredModalInstance : IDisposable
 
     [Parameter, EditorRequired] public RenderFragment Content { get; set; } = default!;
     [Parameter, EditorRequired] public ModalOptions Options { get; set; } = default!;
-    [Parameter] public string? Title { get; set; }
+    [Parameter] public string? Title { get => _title; set => _title ??= value; }
     [Parameter] public Guid Id { get; set; }
 
     private string? Position { get; set; }
@@ -32,6 +32,7 @@ public partial class BlazoredModalInstance : IDisposable
     private bool _setFocus;
     private bool _disableNextRender;
     private bool _listenToBackgroundClicks;
+    private string? _title { get; set; }
 
     // Temporarily add a tabindex of -1 to the close button so it doesn't get selected as the first element by activateFocusTrap
     private readonly Dictionary<string, object> _closeBtnAttributes = new() { { "tabindex", "-1" } };
@@ -78,7 +79,7 @@ public partial class BlazoredModalInstance : IDisposable
     /// <param name="title">Text to display as the title of the modal</param>
     public void SetTitle(string title)
     {
-        Title = title;
+        _title = title;
         StateHasChanged();
     }
 


### PR DESCRIPTION
I have found a problem with raising nested modals on a page, specifically where the title of the "parent" modal has been set with `SetTitle()`.

You can reproduce the problem by trying the following in your  _Blazored.Modal_ BlazorWebAssembly  sample project:

- In `MultipleModals.razor` , see how you are opening a first Modal : `Modal.Show<YesNoPrompt>("First Modal");`
- Modify the `YesNoPrompt` component, to change its own Modal Title :

`    protected override void OnInitialized()
    {
        BlazoredModal.SetTitle("First Modal v2");
    }`

Now do this:

1. Run the sample WASM 
2. Visit the MultipleModals page, and click the "Show Modal" button
3. See that the First Modal Title has been set to "First Modal v2" correctly
4. Click the "Yes" button on the First Modal
5. Click the "Cancel" button on the Second Modal
6. You will see that the First Modal has now lost its "First Modal v2" title, and fallen back to the original title of "First Modal".

I believe this is due to the original `Title` parameter being automatically reset by Blazor's RenderFragment mechanism.

So, my fix in this pull request is to use a private `_title` variable in the modal instance, which is written to once only by the Parameter, and subsequently only modified by use of the `SetTitle` method. Please let me know what you think.

Cheers, James
