### PR TITLE
Remove should render always being false for the focus trap

### DIFF
--- a/src/Blazored.Modal/FocusTrap.razor
+++ b/src/Blazored.Modal/FocusTrap.razor
@@ -17,9 +17,6 @@
     [Parameter] public RenderFragment ChildContent { get; set; } = default!;
     [Parameter] public bool IsActive { get; set; }
 
-    protected override bool ShouldRender()
-        => false;
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)


### PR DESCRIPTION
Fix for the following [issue](https://github.com/Blazored/Modal/issues/565).

Essentially, set title stopped working because the title is used as part of the child content for the FocusTrap component, where the FocusTrap is set to never re-render. This essentially means that its children never re-render, leading to the title never being set. You can see examples and more in the [issue](https://github.com/Blazored/Modal/issues/565).

The fix just allows for the focus trap to re-render. 