### PR TITLE
Remove '?' from javascript to prevent error

### DIFF
--- a/src/Blazored.Modal/BlazoredModal.razor.js
+++ b/src/Blazored.Modal/BlazoredModal.razor.js
@@ -11,7 +11,7 @@ const getScrollBarWidth = () => {
 }
 const isScrollbarPresent = () => {
     const beforeScrollbarHidden = document.body.clientWidth;
-    const overflowState = document.body?.style.overflow;
+    const overflowState = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     const afterScrollbarHidden = document.body.clientWidth;
     document.body.style.overflow = overflowState;


### PR DESCRIPTION
#581 

Adding a '?' works for web, but running Blazored.Modal on a .NET MAUI Blazor Hybrid app causes the javascript to fail.