### PR TITLE
Do single rendering of FocusTrap after SetTitle

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -79,6 +79,12 @@ public partial class BlazoredModalInstance : IDisposable
     public void SetTitle(string title)
     {
         Title = title;
+
+        if (FocusTrap is not null)
+        {
+            FocusTrap.SetRenderRequest();
+        }
+
         StateHasChanged();
     }
 

--- a/src/Blazored.Modal/FocusTrap.razor
+++ b/src/Blazored.Modal/FocusTrap.razor
@@ -13,12 +13,21 @@
     private ElementReference _endFirst;
     private ElementReference _endSecond;
     private bool _shiftPressed;
+    private bool _renderRequest;
 
     [Parameter] public RenderFragment ChildContent { get; set; } = default!;
     [Parameter] public bool IsActive { get; set; }
 
     protected override bool ShouldRender()
-        => false;
+    {
+        if (_renderRequest)
+        {
+            _renderRequest = false;
+            return true;
+        }
+        
+        return false;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -54,4 +63,7 @@
             _shiftPressed = args.ShiftKey;
         }
     }
+
+    internal void SetRenderRequest()
+        => _renderRequest = true;
 }


### PR DESCRIPTION
Fix for the following issue https://github.com/Blazored/Modal/issues/565 and in addition to the closed PR https://github.com/Blazored/Modal/pull/573

With this PR it is possible to use the SetTitle method again. Since only a single re-render is triggered when setting the title, it should not cause any perf issues due to multiple re-rendering.


P.S please forgive me, I'm not that familiar with PRs on GH yet. I hope I did that correctly 😃 
