### PR TITLE
Added modal's Size class when using a custom Class

### DIFF
--- a/src/Blazored.Modal/BlazoredModalInstance.razor
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor
@@ -13,7 +13,7 @@ else
         @onclick="StopListeningToBackgroundClick">
 
         <FocusTrap @ref="FocusTrap" IsActive="ActivateFocusTrap">
-            <div class="@ModalClass" role="dialog" aria-modal="true" @onmouseup:stopPropagation="true" @onmousedown:stopPropagation="true">
+            <div class="@ModalClass @Size" role="dialog" aria-modal="true" @onmouseup:stopPropagation="true" @onmousedown:stopPropagation="true">
                 @if (!HideHeader)
                 {
                     <div class="bm-header">

--- a/src/Blazored.Modal/BlazoredModalInstance.razor.cs
+++ b/src/Blazored.Modal/BlazoredModalInstance.razor.cs
@@ -15,6 +15,7 @@ public partial class BlazoredModalInstance : IDisposable
     [Parameter] public Guid Id { get; set; }
 
     private string? Position { get; set; }
+    private string? Size { get; set; }
     private string? ModalClass { get; set; }
     private bool HideHeader { get; set; }
     private bool HideCloseButton { get; set; }
@@ -129,6 +130,7 @@ public partial class BlazoredModalInstance : IDisposable
     {
         AnimationType = SetAnimation();
         Position = SetPosition();
+        Size = SetSize();
         ModalClass = SetModalClass();
         HideHeader = SetHideHeader();
         HideCloseButton = SetHideCloseButton();
@@ -268,7 +270,6 @@ public partial class BlazoredModalInstance : IDisposable
         if (string.IsNullOrWhiteSpace(modalClass))
         {
             modalClass = "blazored-modal";
-            modalClass += $" {SetSize()}";
         }
 
         return modalClass;


### PR DESCRIPTION
If someone uses `Class = "my-custom-class"`, `Size` and `SizeCustomClass` won't be applied. As `Position` and `PositionCustomClass` can, this seems like an incoherence in behaviour.

I have added the possibility to set the `Size` value regardless of `Class` being set.