### PR TITLE
Fixed ObjectDisposedException in Blazor Web App (InteractiveWebAssembly to StreamRendering mode)

### DIFF
--- a/src/Blazored.Modal/Blazored.Modal.csproj
+++ b/src/Blazored.Modal/Blazored.Modal.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -146,15 +146,15 @@
         _haveActiveModals = false;
         if (_styleFunctions is not null)
         {
-      try
-      {
-            await _styleFunctions.InvokeVoidAsync("removeBodyStyle");
+            try
+            {
+                await _styleFunctions.InvokeVoidAsync("removeBodyStyle");
+            }
+            catch (ObjectDisposedException)
+            {
+              // If the we're working in hybrid scenario for Blazor Web App, where JsRuntime is not available, we don't need to do anything
+            }
         }
-      catch (ObjectDisposedException)
-      {
-        // If the we're working in hybrid scenario for Blazor Web App, where JsRuntime is not available, we don't need to do anything
-      }
-    }
     }
 
     async ValueTask IAsyncDisposable.DisposeAsync()

--- a/src/Blazored.Modal/BlazoredModal.razor
+++ b/src/Blazored.Modal/BlazoredModal.razor
@@ -146,8 +146,15 @@
         _haveActiveModals = false;
         if (_styleFunctions is not null)
         {
+      try
+      {
             await _styleFunctions.InvokeVoidAsync("removeBodyStyle");
         }
+      catch (ObjectDisposedException)
+      {
+        // If the we're working in hybrid scenario for Blazor Web App, where JsRuntime is not available, we don't need to do anything
+      }
+    }
     }
 
     async ValueTask IAsyncDisposable.DisposeAsync()


### PR DESCRIPTION
Added a `try-catch` block around the `InvokeVoidAsync` method call to
handle potential `ObjectDisposedException` exceptions. This ensures
graceful handling of scenarios where the JavaScript runtime might
not be available, such as in a hybrid Blazor Web App environment.
The catch block includes a comment explaining that no action is
needed if this exception occurs.

Fix of issue #594 